### PR TITLE
PR1-W4: Lobby State, Roles, and Player Identity

### DIFF
--- a/crates/unfoundation-core/src/colors.rs
+++ b/crates/unfoundation-core/src/colors.rs
@@ -30,6 +30,9 @@ pub const DIALOG_TEXT_COLOR: Color = Color::srgba(1.0, 1.0, 1.0, 0.7);
 pub const DIALOG_BOLD_TEXT_COLOR: Color = Color::srgba(0.0, 0.8, 1.0, 0.9);
 
 pub fn player_color(index: usize) -> Color {
+    if index >= 9 {
+        return Color::WHITE;
+    }
     let i = index as f32;
     // Math: Hue(i) = (23 + (i * 3 + (i / 3)) * 40) % 360
     // Simplified for 9 players with stride 3:

--- a/crates/unmainmenu-plugin/src/mainmenu.rs
+++ b/crates/unmainmenu-plugin/src/mainmenu.rs
@@ -21,6 +21,7 @@ pub(crate) enum MenuID {
     Hub,
     Manual,
     Settings,
+    Disconnect,
     #[cfg(not(target_arch = "wasm32"))]
     Quit,
 }
@@ -34,6 +35,7 @@ impl std::fmt::Display for MenuID {
             MenuID::Hub => "Play Online",
             MenuID::Manual => "Manual",
             MenuID::Settings => "Settings",
+            MenuID::Disconnect => "Disconnect from Server",
             #[cfg(not(target_arch = "wasm32"))]
             MenuID::Quit => "Quit",
         };
@@ -73,18 +75,32 @@ pub(crate) fn setup_ui(
     ui_assets: Res<UiAssets>,
     player_profile: Res<Persistent<PlayerProfileData>>,
     lobby_presence: Option<Res<untypes_core::roles::LobbyPresenceRole>>,
+    authority: Option<Res<untypes_core::roles::AuthorityRole>>,
 ) {
-    let mut menu_items = if lobby_presence.is_none() {
+    let is_pure_client = lobby_presence.is_some() && authority.is_none();
+
+    let mut menu_items = if is_pure_client {
+        // Hub Client / Join-only: can only go to the lobby, or disconnect.
+        vec![
+            (
+                MenuID::MultiplayerLobby,
+                MenuID::MultiplayerLobby.to_string(),
+            ),
+            (MenuID::Disconnect, MenuID::Disconnect.to_string()),
+        ]
+    } else if lobby_presence.is_some() {
+        // PeerHost or Dedicated with local player: show lobby entry.
+        vec![(
+            MenuID::MultiplayerLobby,
+            MenuID::MultiplayerLobby.to_string(),
+        )]
+    } else {
+        // Offline single-player: full menu.
         vec![
             (MenuID::Campaign, MenuID::Campaign.to_string()),
             (MenuID::CustomMission, MenuID::CustomMission.to_string()),
             (MenuID::Hub, MenuID::Hub.to_string()),
         ]
-    } else {
-        vec![(
-            MenuID::MultiplayerLobby,
-            MenuID::MultiplayerLobby.to_string(),
-        )]
     };
 
     menu_items.extend(vec![
@@ -138,6 +154,7 @@ pub(crate) fn menu_event(
     mut next_map_hub_state: ResMut<NextState<MapHubState>>,
     mut current_mission_select_mode: ResMut<CurrentMissionSelectMode>,
     menu_items: Query<(&MenuID, &MenuItemInteractive)>,
+    mut ev_disconnect: MessageWriter<untypes_core::roles::DisconnectRequest>,
 ) {
     for ev in click_events.read() {
         if ev.state != AppState::MainMenu {
@@ -178,6 +195,13 @@ pub(crate) fn menu_event(
                 MenuID::Settings => {
                     next_app_state.set(AppState::SettingsMenu);
                     info!("Transitioning to SettingsMenu state");
+                }
+                MenuID::Disconnect => {
+                    ev_disconnect.write(untypes_core::roles::DisconnectRequest);
+                    // The actual teardown happens in unreplicon-plugin/connection.rs.
+                    // Transition back to MainMenu so setup_ui re-runs and shows the offline menu.
+                    next_app_state.set(AppState::MainMenu);
+                    info!("DisconnectRequest sent; transitioning to MainMenu");
                 }
                 #[cfg(not(target_arch = "wasm32"))]
                 MenuID::Quit => {

--- a/crates/unreplicon-plugin/src/systems/connection.rs
+++ b/crates/unreplicon-plugin/src/systems/connection.rs
@@ -33,6 +33,39 @@ pub(super) fn app_setup(app: &mut App) {
     );
     app.add_systems(Update, monitor_renet_client_status);
     app.add_systems(Update, monitor_renet_server_clients);
+    app.add_systems(
+        Update,
+        handle_disconnect_request.run_if(resource_exists::<untypes_core::roles::LobbyPresenceRole>),
+    );
+}
+
+fn handle_disconnect_request(
+    mut ev: MessageReader<untypes_core::roles::DisconnectRequest>,
+    mut commands: Commands,
+    q_replicated: Query<Entity, With<bevy_replicon::prelude::Replicated>>,
+) {
+    if ev.is_empty() {
+        return;
+    }
+    ev.clear();
+
+    info!("DisconnectRequest received — tearing down client transport and resetting to offline authority");
+
+    // 1. Remove the transport-layer resources. bevy_renet stops ticking
+    //    and closes the UDP socket automatically when these are dropped.
+    commands.remove_resource::<RenetClient>();
+    commands.remove_resource::<NetcodeClientTransport>();
+
+    // 2. Despawn all entities that were replicated from the remote server.
+    for entity in q_replicated.iter() {
+        commands.entity(entity).despawn();
+    }
+
+    // 3. Retract the network role resources and restore local authority.
+    commands.remove_resource::<untypes_core::roles::LobbyPresenceRole>();
+    commands.insert_resource(untypes_core::roles::AuthorityRole::default());
+
+    // 4. (Callers are responsible for transitioning AppState back to MainMenu or similar.)
 }
 
 fn startup_transport_system(

--- a/crates/unreplicon-plugin/src/systems/lobby.rs
+++ b/crates/unreplicon-plugin/src/systems/lobby.rs
@@ -24,6 +24,9 @@ pub(super) fn app_setup(app: &mut App) {
     app.replicate::<ServerGamePhase>();
     app.replicate::<SelectedMission>();
 
+    // Register local UI messages
+    app.add_message::<untypes_core::roles::DisconnectRequest>();
+
     // Initialize resources that are referenced by lobby UI systems.
     app.init_resource::<ClientUuidMap>();
     app.init_resource::<LocalPlayer>();
@@ -54,8 +57,12 @@ pub(super) fn app_setup(app: &mut App) {
 
     // Server-side lobby lifecycle
     app.add_systems(
+        Update,
+        spawn_lobby_entity_if_missing.run_if(resource_exists::<AuthorityRole>),
+    );
+    app.add_systems(
         OnEnter(AppState::Lobby),
-        setup_lobby_entity.run_if(resource_exists::<AuthorityRole>),
+        reset_lobby_entity_on_reenter.run_if(resource_exists::<AuthorityRole>),
     );
 
     // Server-side: broadcast InGame state to clients when the mission starts.
@@ -120,19 +127,15 @@ fn auto_start_headless_lobby(
     }
 }
 
-/// Spawn (or reset) the authoritative lobby-state entity when the server enters Lobby.
-fn setup_lobby_entity(
-    mut q_existing: Query<(&mut LobbyInfo, &mut ServerGamePhase)>,
+/// Spawn the authoritative lobby-state entity if it's missing.
+fn spawn_lobby_entity_if_missing(
+    q_lobby: Query<(), With<LobbyInfo>>,
     mut commands: Commands,
     local_player: Option<Res<LocalPlayerRole>>,
     runtime_id: Option<Res<RuntimeInstallationId>>,
     mut uuid_map: ResMut<ClientUuidMap>,
 ) {
-    if let Ok((mut lobby, mut game_phase)) = q_existing.single_mut() {
-        // Re-entering Lobby after a mission: reset selection, signal state change.
-        *game_phase = ServerGamePhase::Lobby;
-        lobby.selected_map = None;
-        info!("Lobby entity reset for new session");
+    if !q_lobby.is_empty() {
         return;
     }
 
@@ -140,9 +143,7 @@ fn setup_lobby_entity(
     let mut players = Vec::new();
     let mut leader_uuid = None;
 
-    if local_player.is_some()
-        && let Some(id) = runtime_id
-    {
+    if local_player.is_some() && let Some(id) = runtime_id {
         let uuid = id.0;
         players.push(LobbyPlayerInfo {
             player_uuid: uuid,
@@ -166,6 +167,18 @@ fn setup_lobby_entity(
         ServerGamePhase::Lobby,
     ));
     info!("Lobby entity spawned (leader={:?})", leader_uuid);
+}
+
+/// Reset the authoritative lobby-state entity when the server re-enters Lobby.
+fn reset_lobby_entity_on_reenter(mut q_existing: Query<(&mut LobbyInfo, &mut ServerGamePhase)>) {
+    if let Ok((mut lobby, mut game_phase)) = q_existing.single_mut() {
+        // Re-entering Lobby after a mission: reset selection, signal state change.
+        *game_phase = ServerGamePhase::Lobby;
+        lobby.selected_map = None;
+        info!("Lobby entity reset for new session");
+    } else {
+        warn!("reset_lobby_entity_on_reenter: Lobby entity not found!");
+    }
 }
 
 /// Server: write `ServerGamePhase::InProgress` on the lobby entity when the server
@@ -231,7 +244,16 @@ fn process_newly_connected_clients(
                 }
             } else {
                 // New player
-                let color_index = lobby.players.len() as u8;
+                // Find the lowest colour slot (0..=8) not currently used by any player.
+                let mut used = [false; 9];
+                for p in lobby.players.iter() {
+                    let idx = p.tint_color_index as usize;
+                    if idx < 9 {
+                        used[idx] = true;
+                    }
+                }
+                let color_index = used.iter().position(|&u| !u).unwrap_or(9) as u8;
+
                 lobby.players.push(LobbyPlayerInfo {
                     player_uuid: uuid,
                     current_socket: Some(owner_id),
@@ -256,19 +278,40 @@ fn process_newly_connected_clients(
 
 fn on_client_disconnected(
     trigger: On<Remove, ConnectedClient>,
-    mut q_lobby: Query<&mut LobbyInfo>,
+    mut q_lobby: Query<(&mut LobbyInfo, &ServerGamePhase)>,
     uuid_map: Res<ClientUuidMap>,
+    mut commands: Commands,
+    q_sprites: Query<(Entity, &unplayer_core::components::PlayerSprite)>,
 ) {
     let client_id = ClientId::Client(trigger.entity);
     let Some(uuid) = client_uuid(client_id, &uuid_map) else {
         return;
     };
 
-    for mut lobby in q_lobby.iter_mut() {
-        if let Some(player) = lobby.players.iter_mut().find(|p| p.player_uuid == uuid) {
-            player.connected = false;
-            player.current_socket = None;
-            info!("Player {} disconnected", uuid);
+    for (mut lobby, phase) in q_lobby.iter_mut() {
+        if *phase == ServerGamePhase::Lobby {
+            // Hard remove
+            lobby.players.retain(|p| p.player_uuid != uuid);
+            info!(
+                "Player {} hard-removed from lobby (ServerGamePhase::Lobby)",
+                uuid
+            );
+        } else {
+            // Soft remove
+            if let Some(player) = lobby.players.iter_mut().find(|p| p.player_uuid == uuid) {
+                player.connected = false;
+                player.current_socket = None;
+                info!("Player {} soft-disconnected (phase={:?})", uuid, phase);
+            }
+            if let Some((entity, _)) = q_sprites.iter().find(|(_, s)| s.id == uuid) {
+                commands
+                    .entity(entity)
+                    .insert(unplayer_core::components::PlayerDisconnected);
+                info!(
+                    "Inserted PlayerDisconnected on avatar entity for player {}",
+                    uuid
+                );
+            }
         }
 
         // If the leader left, assign leadership to the next connected player.

--- a/crates/untypes-core/src/roles.rs
+++ b/crates/untypes-core/src/roles.rs
@@ -21,3 +21,11 @@ pub fn is_pure_client(
 ) -> bool {
     local.is_some() && authority.is_none()
 }
+
+/// Sent by the UI when the local player wants to disconnect from the current
+/// multiplayer session and return to single-player offline authority.
+///
+/// Consumed exclusively by `unreplicon-plugin/src/systems/connection.rs`.
+/// The UI must not directly manipulate transport resources; it only writes this message.
+#[derive(bevy::prelude::Message, Debug, Clone)]
+pub struct DisconnectRequest;


### PR DESCRIPTION
Refactored lobby lifecycle, player color assignment, and connection teardown to use a Data-Driven and Role-Based ECS architecture. Key changes include:
- Fixed the color pool using a "Lowest Available Slot" algorithm and added a White fallback for more than 9 players.
- Decoupled lobby entity creation from UI state, ensuring it exists whenever the process is in an authority role.
- Implemented context-aware disconnects with hard-removal during Lobby and soft-removal during missions.
- Added a role-based "Disconnect from Server" UI option for pure clients with clean transport teardown.

---
*PR created automatically by Jules for task [16129088004762322854](https://jules.google.com/task/16129088004762322854) started by @deavid*