### PR TITLE
Rapid Idle Timeout for Dedicated Servers

### DIFF
--- a/crates/unreplicon-transport/src/systems/procman.rs
+++ b/crates/unreplicon-transport/src/systems/procman.rs
@@ -7,7 +7,7 @@ use crate::resources::{ProcManChannel, ProcManConfig, RoomAuth};
 pub(super) fn app_setup(app: &mut App) {
     app.init_resource::<RoomAuth>();
     app.add_systems(Startup, setup_procman_system);
-    app.add_systems(Update, update_procman_system);
+    app.add_systems(Update, (update_procman_system, idle_timeout_system));
 }
 
 fn setup_procman_system(mut commands: Commands, procman_config: Res<ProcManConfig>) {
@@ -87,5 +87,33 @@ fn update_procman_system(
                 exit.write(bevy::app::AppExit::Success);
             }
         }
+    }
+}
+
+/// Automatically shut down the dedicated server if it's empty and was created via unhub.
+fn idle_timeout_system(
+    time: Res<Time>,
+    procman: Option<Res<ProcManChannel>>,
+    room_auth: Res<RoomAuth>,
+    server: Option<Res<bevy_renet::RenetServer>>,
+    mut idle_timer: Local<f32>,
+    mut exit: MessageWriter<bevy::app::AppExit>,
+) {
+    // Only apply to unhub-managed servers (those with a procman channel and an assigned room).
+    if procman.is_none() || room_auth.room_code.is_none() {
+        *idle_timer = 0.0;
+        return;
+    }
+
+    let client_count = server.map(|s| s.clients_id().len()).unwrap_or(0);
+
+    if client_count == 0 {
+        *idle_timer += time.delta_secs();
+        if *idle_timer >= 5.0 {
+            info!("Dedicated server is empty and idle for 5s; shutting down.");
+            exit.write(bevy::app::AppExit::Success);
+        }
+    } else {
+        *idle_timer = 0.0;
     }
 }

--- a/crates/unreplicon-transport/src/systems/procman.rs
+++ b/crates/unreplicon-transport/src/systems/procman.rs
@@ -97,6 +97,7 @@ fn idle_timeout_system(
     room_auth: Res<RoomAuth>,
     server: Option<Res<bevy_renet::RenetServer>>,
     mut idle_timer: Local<f32>,
+    mut exit_sent: Local<bool>,
     mut exit: MessageWriter<bevy::app::AppExit>,
 ) {
     // Only apply to unhub-managed servers (those with a procman channel and an assigned room).
@@ -114,9 +115,10 @@ fn idle_timeout_system(
 
     if client_count == 0 {
         *idle_timer += time.delta_secs();
-        if *idle_timer >= 5.0 {
+        if *idle_timer >= 5.0 && !*exit_sent {
             info!("Dedicated server is empty and idle for 5s; shutting down.");
             exit.write(bevy::app::AppExit::Success);
+            *exit_sent = true;
         }
     } else {
         *idle_timer = 0.0;

--- a/crates/unreplicon-transport/src/systems/procman.rs
+++ b/crates/unreplicon-transport/src/systems/procman.rs
@@ -105,7 +105,12 @@ fn idle_timeout_system(
         return;
     }
 
-    let client_count = server.map(|s| s.clients_id().len()).unwrap_or(0);
+    let Some(server) = server else {
+        *idle_timer = 0.0;
+        return;
+    };
+
+    let client_count = server.clients_id().len();
 
     if client_count == 0 {
         *idle_timer += time.delta_secs();


### PR DESCRIPTION
Implemented an idle timeout system for dedicated game servers. When a server is created via `unhub` (indicated by the presence of a process manager channel and an assigned room code), it will now automatically shut down if there are zero connected clients for more than 5 seconds. This is achieved using a new `idle_timeout_system` that tracks inactivity and emits an `AppExit` signal. The check for an assigned room code ensures that the server doesn't shut down prematurely during its initial boot and setup phase.

---
*PR created automatically by Jules for task [18267086856620775761](https://jules.google.com/task/18267086856620775761) started by @deavid*