### PR TITLE
Make Main Menu reactive to connection state changes

### DIFF
--- a/crates/unhub-plugin/src/ui.rs
+++ b/crates/unhub-plugin/src/ui.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use uncommon_app_core::platform::plt;
 use uncommon_states_core::UIContextState;
 use unmenu_core::assets::MenuAssets;
-use unmenu_core::components::{MCamera, MenuItemInteractive, MenuUI};
+use unmenu_core::components::{MCamera, MenuItemInteractive, MenuRoot, MenuUI};
 use unmenu_core::events::{MenuEscapeEvent, MenuItemClicked};
 use unmenu_core::templates;
 use unreplicon_core::components::LobbyInfo;
@@ -26,6 +26,9 @@ pub struct HubMenuMarker;
 
 #[derive(Component)]
 pub struct HubCodeDisplay;
+
+#[derive(Component)]
+pub struct HubCodeText;
 
 #[derive(Component)]
 pub struct HubStatusLabel;
@@ -74,15 +77,14 @@ pub fn setup_hub_ui(mut commands: Commands, ui_assets: Res<MenuAssets>) {
 
     commands.entity(root_entity).with_children(|parent| {
         parent
-            .spawn((
-                Node {
-                    position_type: PositionType::Absolute,
-                    right: Val::Px(50.0 * plt::UI_SCALE),
-                    top: Val::Px(100.0 * plt::UI_SCALE),
-                    ..default()
-                },
-                HubCodeDisplay,
-            ))
+            .spawn(Node {
+                position_type: PositionType::Absolute,
+                right: Val::Px(50.0 * plt::UI_SCALE),
+                top: Val::Px(100.0 * plt::UI_SCALE),
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::FlexEnd,
+                ..default()
+            })
             .with_children(|node| {
                 node.spawn((
                     Text::new("CODE: _____"),
@@ -92,6 +94,16 @@ pub fn setup_hub_ui(mut commands: Commands, ui_assets: Res<MenuAssets>) {
                         ..default()
                     },
                     TextColor(Color::WHITE),
+                    HubCodeText,
+                ));
+                node.spawn((
+                    Text::new("Type code using your keyboard"),
+                    TextFont {
+                        font: ui_assets.font_titillium_light.clone(),
+                        font_size: 20.0 * plt::FONT_SCALE,
+                        ..default()
+                    },
+                    TextColor(Color::srgba(1.0, 1.0, 1.0, 0.5)),
                 ));
             });
 
@@ -189,11 +201,13 @@ pub fn despawn_hub_ui(
 pub fn update_code_input(
     mut evr_char: MessageReader<KeyboardInput>,
     mut code_input: ResMut<RoomCodeInput>,
-    q_display: Query<&Children, With<HubCodeDisplay>>,
-    mut q_text: Query<&mut Text>,
+    mut q_text: Query<&mut Text, With<HubCodeText>>,
     hub_client: Res<HubClient>,
     mut hub_status: ResMut<HubStatus>,
     runtime_installation_id: Option<Res<unprofile_core::profile::RuntimeInstallationId>>,
+    time: Res<Time>,
+    mut q_menu_root: Query<&mut MenuRoot>,
+    mut last_len: Local<usize>,
 ) {
     for ev in evr_char.read() {
         if ev.state == bevy::input::ButtonState::Released {
@@ -244,16 +258,25 @@ pub fn update_code_input(
         }
     }
 
-    for children in &q_display {
-        for child in children.iter() {
-            if let Ok(mut text) = q_text.get_mut(child.to_owned()) {
-                let mut display = code_input.0.clone();
-                while display.len() < 5 {
-                    display.push('_');
-                }
-                text.0 = format!("CODE: {}", display);
+    if code_input.0.len() == 5 && *last_len < 5 {
+        if let Ok(mut menu_root) = q_menu_root.get_single_mut() {
+            menu_root.selected_item = 1; // HubMenuID::JoinRoom index
+        }
+    }
+    *last_len = code_input.0.len();
+
+    let show_cursor = (time.elapsed_secs() * 2.0) as i32 % 2 == 0;
+
+    for mut text in &mut q_text {
+        let mut display = code_input.0.clone();
+        if display.len() < 5 {
+            let cursor = if show_cursor { '_' } else { ' ' };
+            display.push(cursor);
+            while display.len() < 5 {
+                display.push('_');
             }
         }
+        text.0 = format!("CODE: {}", display);
     }
 }
 

--- a/crates/unhub-plugin/src/ui.rs
+++ b/crates/unhub-plugin/src/ui.rs
@@ -77,14 +77,17 @@ pub fn setup_hub_ui(mut commands: Commands, ui_assets: Res<MenuAssets>) {
 
     commands.entity(root_entity).with_children(|parent| {
         parent
-            .spawn(Node {
-                position_type: PositionType::Absolute,
-                right: Val::Px(50.0 * plt::UI_SCALE),
-                top: Val::Px(100.0 * plt::UI_SCALE),
-                flex_direction: FlexDirection::Column,
-                align_items: AlignItems::FlexEnd,
-                ..default()
-            })
+            .spawn((
+                Node {
+                    position_type: PositionType::Absolute,
+                    right: Val::Px(50.0 * plt::UI_SCALE),
+                    top: Val::Px(100.0 * plt::UI_SCALE),
+                    flex_direction: FlexDirection::Column,
+                    align_items: AlignItems::FlexEnd,
+                    ..default()
+                },
+                HubCodeDisplay,
+            ))
             .with_children(|node| {
                 node.spawn((
                     Text::new("CODE: _____"),
@@ -208,6 +211,7 @@ pub fn update_code_input(
     time: Res<Time>,
     mut q_menu_root: Query<&mut MenuRoot>,
     mut last_len: Local<usize>,
+    q_menu_items: Query<(&HubMenuID, &MenuItemInteractive)>,
 ) {
     for ev in evr_char.read() {
         if ev.state == bevy::input::ButtonState::Released {
@@ -259,8 +263,13 @@ pub fn update_code_input(
     }
 
     if code_input.0.len() == 5 && *last_len < 5 {
-        if let Ok(mut menu_root) = q_menu_root.get_single_mut() {
-            menu_root.selected_item = 1; // HubMenuID::JoinRoom index
+        if let Some((_, item)) = q_menu_items
+            .iter()
+            .find(|(id, _)| **id == HubMenuID::JoinRoom)
+        {
+            if let Ok(mut menu_root) = q_menu_root.get_single_mut() {
+                menu_root.selected_item = item.identifier;
+            }
         }
     }
     *last_len = code_input.0.len();

--- a/crates/unmainmenu-plugin/src/mainmenu.rs
+++ b/crates/unmainmenu-plugin/src/mainmenu.rs
@@ -51,16 +51,44 @@ pub(crate) struct MenuUILayout;
 pub(crate) struct UpgradeNotificationBanner;
 
 pub(crate) fn app_setup(app: &mut App) {
-    app.add_systems(OnEnter(UIContextState::MainMenu), (setup, setup_ui))
+    app.add_systems(OnEnter(UIContextState::MainMenu), setup)
         .add_systems(
             Update,
             (
+                watch_connection_state,
+                apply_deferred,
+                setup_ui.run_if(menu_ui_is_missing),
                 menu_event,
                 update_hub_button_availability,
                 update_upgrade_notification,
             )
+                .chain()
                 .run_if(in_state(UIContextState::MainMenu)),
         );
+}
+
+fn menu_ui_is_missing(q_ui: Query<(), With<MenuUI>>) -> bool {
+    q_ui.is_empty()
+}
+
+fn watch_connection_state(
+    lobby_presence: Option<Res<LobbyPresenceRole>>,
+    authority: Option<Res<AuthorityRole>>,
+    mut last_state: Local<Option<(bool, bool)>>,
+    q_ui: Query<Entity, With<MenuUI>>,
+    mut commands: Commands,
+) {
+    let current_state = (lobby_presence.is_some(), authority.is_some());
+    if last_state.is_none() {
+        *last_state = Some(current_state);
+        return;
+    }
+    if Some(current_state) != *last_state {
+        for entity in q_ui.iter() {
+            commands.entity(entity).despawn();
+        }
+        *last_state = Some(current_state);
+    }
 }
 
 pub(crate) fn setup(mut player_profile: ResMut<Persistent<PlayerProfileData>>) {

--- a/crates/unmainmenu-plugin/src/mainmenu.rs
+++ b/crates/unmainmenu-plugin/src/mainmenu.rs
@@ -56,7 +56,6 @@ pub(crate) fn app_setup(app: &mut App) {
             Update,
             (
                 watch_connection_state,
-                apply_deferred,
                 setup_ui.run_if(menu_ui_is_missing),
                 menu_event,
                 update_hub_button_availability,


### PR DESCRIPTION
The Main Menu now updates in real-time when the player's connection state changes. Previously, clicking "Disconnect from server" would send the request, but the UI would only update after manually returning to the menu or a state transition. Now, the `unmainmenu-plugin` monitors the relevant connection resources (`LobbyPresenceRole` and `AuthorityRole`) and automatically triggers a UI rebuild when they change. This provides immediate visual feedback that the disconnection process has started or completed.

---
*PR created automatically by Jules for task [16196689841842331658](https://jules.google.com/task/16196689841842331658) started by @deavid*