### PR TITLE
Show all players' sanity and health in truck UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8751,6 +8751,7 @@ dependencies = [
  "untruck-core",
  "unvitals-core",
  "unwalkie-core",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/untruckui-plugin/Cargo.toml
+++ b/crates/untruckui-plugin/Cargo.toml
@@ -35,3 +35,4 @@ bevy = { workspace = true }
 bevy_asset_loader = { workspace = true }
 bevy_platform = { workspace = true }
 bevy-persistent = { workspace = true }
+uuid = { workspace = true }

--- a/crates/untruckui-plugin/src/sanity.rs
+++ b/crates/untruckui-plugin/src/sanity.rs
@@ -1,10 +1,16 @@
 use crate::assets::TruckUiAssets;
 use crate::colors;
+use bevy::color::palettes::css;
 use bevy::prelude::*;
+use std::collections::HashMap;
 use uncommon_app_core::platform::plt::{FONT_SCALE, UI_SCALE};
 use uninput_core::states::InGameUiState;
-use unplayer_core::components::{MainPlayer, PlayerSprite};
+use unplayer_core::colors::player_color;
+use unplayer_core::components::{MainPlayer, PlayerDisconnected, PlayerInactive, PlayerSprite};
+use unreplicon_core::components::LobbyInfo;
+use untruck_core::components::in_truck::InTruck;
 use unvitals_core::components::PlayerVitals;
+use uuid::Uuid;
 
 const MARGIN_PERCENT: f32 = 0.5 * UI_SCALE;
 const TEXT_MARGIN: UiRect = UiRect::percent(2.0 * UI_SCALE, 0.0, 0.0, 0.0);
@@ -35,20 +41,16 @@ pub(crate) fn setup_sanity_ui(p: &mut ChildSpawnerCommands, handles: &TruckUiAss
         ..default()
     })
     .insert(BorderColor::all(colors::TRUCKUI_ACCENT_COLOR));
-    let p1_sanity = (
-        Text::new("Loading player data..."),
-        TextFont {
-            font: handles.font_chakra_light.clone(),
-            font_size: 18.0 * FONT_SCALE,
-            ..default()
-        },
-        TextColor(colors::TRUCKUI_TEXT_COLOR),
+
+    p.spawn((
         Node {
             margin: TEXT_MARGIN,
+            flex_direction: FlexDirection::Column,
             ..default()
         },
-    );
-    p.spawn(p1_sanity).insert(SanityText);
+        SanityText,
+    ));
+
     p.spawn(Node {
         justify_content: JustifyContent::FlexStart,
         flex_direction: FlexDirection::Column,
@@ -59,37 +61,148 @@ pub(crate) fn setup_sanity_ui(p: &mut ChildSpawnerCommands, handles: &TruckUiAss
 }
 
 fn update_sanity(
-    qp: Query<(&PlayerVitals, &PlayerSprite, Has<MainPlayer>)>,
-    mut qst: Query<&mut Text, With<SanityText>>,
+    mut commands: Commands,
+    handles: Res<TruckUiAssets>,
+    qp: Query<(
+        &PlayerVitals,
+        &PlayerSprite,
+        Has<MainPlayer>,
+        Has<PlayerDisconnected>,
+        Has<PlayerInactive>,
+        Has<InTruck>,
+    )>,
+    q_lobby: Query<&LobbyInfo>,
+    q_container: Query<Entity, With<SanityText>>,
+    mut q_text: Query<&mut Text>,
+    mut last_order: Local<Vec<(Uuid, bool, bool, bool, bool, u8)>>,
+    mut text_map: Local<HashMap<Uuid, Entity>>,
 ) {
+    let Ok(container_entity) = q_container.single() else {
+        return;
+    };
+
+    let lobby_info = q_lobby.single().ok();
+
     let mut players: Vec<_> = qp.iter().collect();
     players.sort_by(|a, b| {
         // Sort MainPlayer first
         if a.2 != b.2 {
             return b.2.cmp(&a.2);
         }
+        // Then by connection state (Active > Inactive > Disconnected)
+        // a.3=disc, a.4=inact. We want disc last, then inact.
+        let state_score = |disc, inact| if disc { 2 } else if inact { 1 } else { 0 };
+        let score_a = state_score(a.3, a.4);
+        let score_b = state_score(b.3, b.4);
+        if score_a != score_b {
+            return score_a.cmp(&score_b);
+        }
         // Then by network_id
         a.1.network_id.0.cmp(&b.1.network_id.0)
     });
 
-    let mut lines = Vec::new();
-    for (vitals, sprite, _is_main) in players {
-        let name = unreplicon_core::identity::generate_deterministic_name(sprite.id);
-        lines.push(format!(
-            "{}:\n  {:.0}% Sanity, {:.0}% Health",
-            name, vitals.sanity, vitals.health
-        ));
+    let current_order: Vec<_> = players
+        .iter()
+        .map(|(_, s, main, disc, inact, in_truck)| {
+            let tint = lobby_info
+                .and_then(|li| li.players.iter().find(|p| p.player_uuid == s.id))
+                .map(|p| p.tint_color_index)
+                .unwrap_or(0);
+            (s.id, *main, *disc, *inact, *in_truck, tint)
+        })
+        .collect();
+
+    if *last_order != current_order {
+        *last_order = current_order;
+        text_map.clear();
+        commands.entity(container_entity).despawn_children();
+
+        if players.is_empty() {
+            commands.entity(container_entity).with_children(|p| {
+                p.spawn((
+                    Text::new("No player data available"),
+                    TextFont {
+                        font: handles.font_chakra_light.clone(),
+                        font_size: 18.0 * FONT_SCALE,
+                        ..default()
+                    },
+                    TextColor(colors::TRUCKUI_TEXT_COLOR),
+                ));
+            });
+        } else {
+            for (vitals, sprite, _main, is_disc, is_inact, is_in_truck) in &players {
+                let tint = lobby_info
+                    .and_then(|li| li.players.iter().find(|p| p.player_uuid == sprite.id))
+                    .map(|p| p.tint_color_index)
+                    .unwrap_or(0);
+
+                let color = if *is_disc {
+                    css::GRAY.into()
+                } else if *is_inact {
+                    css::YELLOW.into()
+                } else if *is_in_truck {
+                    // Light pale green as requested
+                    Color::srgba(0.7, 0.9, 0.7, 1.0)
+                } else {
+                    colors::TRUCKUI_TEXT_COLOR
+                };
+
+                let player_tint = player_color(tint as usize);
+
+                commands.entity(container_entity).with_children(|p| {
+                    p.spawn(Node {
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        column_gap: Val::Px(5.0 * UI_SCALE),
+                        ..default()
+                    })
+                    .with_children(|row| {
+                        // Tint square
+                        row.spawn((
+                            Node {
+                                width: Val::Px(12.0 * UI_SCALE),
+                                height: Val::Px(12.0 * UI_SCALE),
+                                ..default()
+                            },
+                            BackgroundColor(player_tint),
+                        ));
+                        // Status text
+                        let name = unreplicon_core::identity::generate_deterministic_name(sprite.id);
+                        let status_text = format!(
+                            "{}:\n  {:.0}% Sanity, {:.0}% Health",
+                            name, vitals.sanity, vitals.health
+                        );
+                        let text_entity = row
+                            .spawn((
+                                Text::new(status_text),
+                                TextFont {
+                                    font: handles.font_chakra_light.clone(),
+                                    font_size: 18.0 * FONT_SCALE,
+                                    ..default()
+                                },
+                                TextColor(color),
+                            ))
+                            .id();
+                        text_map.insert(sprite.id, text_entity);
+                    });
+                });
+            }
+        }
     }
 
-    let new_text = if lines.is_empty() {
-        "No player data available".to_string()
-    } else {
-        lines.join("\n")
-    };
-
-    for mut text in &mut qst {
-        if text.0 != new_text {
-            text.0 = new_text.clone();
+    // Update text content every frame
+    for (vitals, sprite, _, _, _, _) in players {
+        if let Some(&text_entity) = text_map.get(&sprite.id) {
+            if let Ok(mut text) = q_text.get_mut(text_entity) {
+                let name = unreplicon_core::identity::generate_deterministic_name(sprite.id);
+                let new_content = format!(
+                    "{}:\n  {:.0}% Sanity, {:.0}% Health",
+                    name, vitals.sanity, vitals.health
+                );
+                if text.0 != new_content {
+                    text.0 = new_content;
+                }
+            }
         }
     }
 }

--- a/crates/untruckui-plugin/src/sanity.rs
+++ b/crates/untruckui-plugin/src/sanity.rs
@@ -36,7 +36,7 @@ pub(crate) fn setup_sanity_ui(p: &mut ChildSpawnerCommands, handles: &TruckUiAss
     })
     .insert(BorderColor::all(colors::TRUCKUI_ACCENT_COLOR));
     let p1_sanity = (
-        Text::new("Player 1: 90% Sanity"),
+        Text::new("Loading player data..."),
         TextFont {
             font: handles.font_chakra_light.clone(),
             font_size: 25.0 * FONT_SCALE,
@@ -59,16 +59,37 @@ pub(crate) fn setup_sanity_ui(p: &mut ChildSpawnerCommands, handles: &TruckUiAss
 }
 
 fn update_sanity(
-    qp: Query<(&PlayerVitals, &PlayerSprite), With<MainPlayer>>,
+    qp: Query<(&PlayerVitals, &PlayerSprite, Has<MainPlayer>)>,
     mut qst: Query<&mut Text, With<SanityText>>,
 ) {
-    for (player, sprite) in &qp {
+    let mut players: Vec<_> = qp.iter().collect();
+    players.sort_by(|a, b| {
+        // Sort MainPlayer first
+        if a.2 != b.2 {
+            return b.2.cmp(&a.2);
+        }
+        // Then by network_id
+        a.1.network_id.0.cmp(&b.1.network_id.0)
+    });
+
+    let mut lines = Vec::new();
+    for (vitals, sprite, _is_main) in players {
         let name = unreplicon_core::identity::generate_deterministic_name(sprite.id);
-        for mut text in &mut qst {
-            let new_sanity_text = format!("{}:\n  {:.0}% Sanity", name, player.sanity);
-            if new_sanity_text != text.0 {
-                text.0 = new_sanity_text;
-            }
+        lines.push(format!(
+            "{}:\n  {:.0}% Sanity, {:.0}% Health",
+            name, vitals.sanity, vitals.health
+        ));
+    }
+
+    let new_text = if lines.is_empty() {
+        "No player data available".to_string()
+    } else {
+        lines.join("\n")
+    };
+
+    for mut text in &mut qst {
+        if text.0 != new_text {
+            text.0 = new_text.clone();
         }
     }
 }

--- a/crates/untruckui-plugin/src/sanity.rs
+++ b/crates/untruckui-plugin/src/sanity.rs
@@ -39,7 +39,7 @@ pub(crate) fn setup_sanity_ui(p: &mut ChildSpawnerCommands, handles: &TruckUiAss
         Text::new("Loading player data..."),
         TextFont {
             font: handles.font_chakra_light.clone(),
-            font_size: 25.0 * FONT_SCALE,
+            font_size: 18.0 * FONT_SCALE,
             ..default()
         },
         TextColor(colors::TRUCKUI_TEXT_COLOR),


### PR DESCRIPTION
The truck's sanity monitor now displays a comprehensive list of all active players in the session. For each player, both their current sanity and health percentages are shown. To improve readability, the local player's information is always pinned to the top of the list. Sanity and health data is updated in real-time as replicated vitals change.

---
*PR created automatically by Jules for task [18038537107513559861](https://jules.google.com/task/18038537107513559861) started by @deavid*