### PR TITLE
Lobby UI fixes and connection error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8079,6 +8079,8 @@ dependencies = [
  "uncommon-app-core",
  "uncommon-states-core",
  "undifficulty-core",
+ "unhub-client",
+ "unhub-plugin",
  "unlobby-core",
  "unmapload-core",
  "unmenu-core",

--- a/crates/tools/unhub/src/api.rs
+++ b/crates/tools/unhub/src/api.rs
@@ -638,11 +638,21 @@ pub async fn join_room(
     }
 
     if !version_found {
-        tracing::warn!(
+        tracing::error!(
             "Room {} uses version {}, but it's not in the hosting ProcMan's library",
             code,
             room.game_version
         );
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(HubError {
+                error: "room_version_unavailable".to_string(),
+                message: format!(
+                    "The room requires game version {}, but the hosting server cannot currently verify its protocol. Please try again later.",
+                    room.game_version
+                ),
+            }),
+        ));
     }
 
     let exp = std::time::SystemTime::now()

--- a/crates/tools/unhub/src/api.rs
+++ b/crates/tools/unhub/src/api.rs
@@ -616,6 +616,35 @@ pub async fn join_room(
         }),
     ))?;
 
+    // Verify protocol hash
+    let mut version_found = false;
+    for entry in &pm.library {
+        if entry.version == room.game_version {
+            version_found = true;
+            if entry.protocol_hash != payload.protocol_hash {
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(HubError {
+                        error: "protocol_mismatch".to_string(),
+                        message: format!(
+                            "Protocol hash mismatch for room {}. Client has {}, but room requires {}.",
+                            code, payload.protocol_hash, entry.protocol_hash
+                        ),
+                    }),
+                ));
+            }
+            break;
+        }
+    }
+
+    if !version_found {
+        tracing::warn!(
+            "Room {} uses version {}, but it's not in the hosting ProcMan's library",
+            code,
+            room.game_version
+        );
+    }
+
     let exp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()

--- a/crates/unhub-client/src/protocol.rs
+++ b/crates/unhub-client/src/protocol.rs
@@ -151,6 +151,7 @@ pub struct CreateRoomRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JoinRoomRequest {
     pub player_uuid: Uuid,
+    pub protocol_hash: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/unhub-plugin/src/hub_client.rs
+++ b/crates/unhub-plugin/src/hub_client.rs
@@ -134,14 +134,17 @@ impl HubClient {
         });
     }
 
-    pub fn join_room(&self, code: String, player_uuid: uuid::Uuid) {
+    pub fn join_room(&self, code: String, player_uuid: uuid::Uuid, protocol_hash: u64) {
         let hub_url = self.hub_url.clone();
         let tx = self.tx.clone();
         spawn_hub_task(async move {
             let client = reqwest::Client::new();
             match client
                 .post(format!("{}/v1/rooms/join/{}", hub_url, code))
-                .json(&JoinRoomRequest { player_uuid })
+                .json(&JoinRoomRequest {
+                    player_uuid,
+                    protocol_hash,
+                })
                 .send()
                 .await
             {
@@ -254,6 +257,8 @@ pub struct HubStatus {
     pub lobby_ready_timer: Option<f32>,
     pub is_online: bool,
     pub online_players: usize,
+    pub error_message: Option<String>,
+    pub error_timer: f32,
 }
 
 #[derive(Resource)]
@@ -333,21 +338,37 @@ pub fn update_hub_status(
     client: Res<HubClient>,
 ) {
     while let Ok(resp) = client.rx.try_recv() {
-        if let HubResponse::PingResult {
-            ok,
-            online_players,
-            multiplayer_status,
-            upgrade_version,
-        } = resp
-        {
-            status.is_online = ok;
-            status.online_players = online_players;
-            hub_connection_status.status = Some(multiplayer_status);
-            hub_connection_status.upgrade_version = upgrade_version;
-            hub_connection_status.last_update = 0.0;
-        } else {
-            status.last_response = Some(resp);
-            status.is_pending = false;
+        if let HubResponse::Error(ref e) = resp {
+            status.error_message = Some(e.clone());
+            status.error_timer = 10.0;
+        }
+
+        match resp {
+            HubResponse::PingResult {
+                ok,
+                online_players,
+                multiplayer_status,
+                upgrade_version,
+            } => {
+                status.is_online = ok;
+                status.online_players = online_players;
+                hub_connection_status.status = Some(multiplayer_status);
+                hub_connection_status.upgrade_version = upgrade_version;
+                hub_connection_status.last_update = 0.0;
+            }
+            _ => {
+                status.last_response = Some(resp);
+                status.is_pending = false;
+            }
+        }
+    }
+}
+
+pub fn hub_error_tick_system(time: Res<Time>, mut status: ResMut<HubStatus>) {
+    if status.error_timer > 0.0 {
+        status.error_timer -= time.delta_secs();
+        if status.error_timer <= 0.0 {
+            status.error_message = None;
         }
     }
 }

--- a/crates/unhub-plugin/src/hub_client.rs
+++ b/crates/unhub-plugin/src/hub_client.rs
@@ -368,6 +368,7 @@ pub fn hub_error_tick_system(time: Res<Time>, mut status: ResMut<HubStatus>) {
     if status.error_timer > 0.0 {
         status.error_timer -= time.delta_secs();
         if status.error_timer <= 0.0 {
+            status.error_timer = 0.0;
             status.error_message = None;
         }
     }

--- a/crates/unhub-plugin/src/plugin.rs
+++ b/crates/unhub-plugin/src/plugin.rs
@@ -40,7 +40,11 @@ impl Plugin for UnhaunterHubPlugin {
         );
         app.add_systems(
             Update,
-            (hub_client::update_hub_status, hub_client::ping_hub_system),
+            (
+                hub_client::update_hub_status,
+                hub_client::ping_hub_system,
+                hub_client::hub_error_tick_system,
+            ),
         );
 
         // UI systems

--- a/crates/unhub-plugin/src/ui.rs
+++ b/crates/unhub-plugin/src/ui.rs
@@ -176,7 +176,7 @@ pub fn hub_menu_event(
                             .as_ref()
                             .map(|x| x.0)
                             .unwrap_or_default();
-                        hub_client.join_room(code, player_uuid);
+                        hub_client.join_room(code, player_uuid, protocol_hash.0);
                         hub_status.is_pending = true;
                     }
                 }
@@ -207,6 +207,7 @@ pub fn update_code_input(
     mut q_text: Query<&mut Text, With<HubCodeText>>,
     hub_client: Res<HubClient>,
     mut hub_status: ResMut<HubStatus>,
+    protocol_hash: Res<ClientProtocolHash>,
     runtime_installation_id: Option<Res<unprofile_core::profile::RuntimeInstallationId>>,
     time: Res<Time>,
     mut q_menu_root: Query<&mut MenuRoot>,
@@ -229,7 +230,7 @@ pub fn update_code_input(
                     .as_ref()
                     .map(|x| x.0)
                     .unwrap_or_default();
-                hub_client.join_room(code, player_uuid);
+                hub_client.join_room(code, player_uuid, protocol_hash.0);
                 hub_status.is_pending = true;
             }
         } else {
@@ -360,20 +361,26 @@ pub fn await_lobby_then_transition(
 /// Updates the Hub screen status label to give connecting feedback.
 pub fn update_hub_status_label(
     hub_status: Res<HubStatus>,
-    mut q_label: Query<&mut Text, With<HubStatusLabel>>,
+    mut q_label: Query<(&mut Text, &mut TextColor), With<HubStatusLabel>>,
 ) {
     if !hub_status.is_changed() {
         return;
     }
-    for mut text in &mut q_label {
-        text.0 = if hub_status.lobby_ready_timer.is_some() {
-            "Ready! Entering lobby…".to_string()
-        } else if hub_status.is_connecting {
-            "CONNECTING… please wait".to_string()
-        } else if hub_status.is_pending {
-            "Contacting Hub…".to_string()
+    for (mut text, mut color) in &mut q_label {
+        if let Some(error) = &hub_status.error_message {
+            text.0 = format!("ERROR: {}", error);
+            color.0 = Color::srgb(1.0, 0.5, 0.0); // Orange
         } else {
-            "".to_string()
-        };
+            color.0 = Color::srgb(1.0, 0.85, 0.2); // Default yellowish-orange
+            text.0 = if hub_status.lobby_ready_timer.is_some() {
+                "Ready! Entering lobby…".to_string()
+            } else if hub_status.is_connecting {
+                "CONNECTING… please wait".to_string()
+            } else if hub_status.is_pending {
+                "Contacting Hub…".to_string()
+            } else {
+                "".to_string()
+            };
+        }
     }
 }

--- a/crates/unlobby-plugin/Cargo.toml
+++ b/crates/unlobby-plugin/Cargo.toml
@@ -26,3 +26,5 @@ unrender-std = { workspace = true }
 bevy-persistent = { workspace = true }
 unlobby-core = { workspace = true }
 unplayer-core = { workspace = true }
+unhub-plugin = { workspace = true }
+unhub-client = { workspace = true }

--- a/crates/unlobby-plugin/src/systems/lobby_main.rs
+++ b/crates/unlobby-plugin/src/systems/lobby_main.rs
@@ -542,7 +542,7 @@ pub(crate) fn update_display(
                     "CRITICAL: Version incompatible".to_string()
                 }
                 Some(unhub_client::protocol::MultiplayerStatus::Conflict) => {
-                    "CRITICAL: Version conflict detected".to_string()
+                    "CRITICAL: Another instance or profile conflict detected".to_string()
                 }
                 _ => "".to_string(),
             }

--- a/crates/unlobby-plugin/src/systems/lobby_main.rs
+++ b/crates/unlobby-plugin/src/systems/lobby_main.rs
@@ -52,6 +52,9 @@ pub(crate) struct DeploymentStatusText;
 #[derive(Component)]
 pub(crate) struct MissionLaunchControl;
 
+#[derive(Component)]
+pub(crate) struct LobbyVersionWarning;
+
 #[derive(Clone, Copy, Component, Debug, PartialEq, Eq)]
 pub(crate) enum LobbyMenuAction {
     SelectMap,
@@ -138,20 +141,14 @@ pub(crate) fn setup_ui(
 
             let mut menu_idx = 0;
             for (action, label) in items {
-                // Always create StartMission and AbortMission for everyone (visibility controlled in update_display)
-                if is_room_owner
-                    || action == LobbyMenuAction::ExitLobby
-                    || action == LobbyMenuAction::StartMission
-                    || action == LobbyMenuAction::AbortMission
-                {
-                    let mut menu_item =
-                        templates::create_menu_item(s, label, menu_idx, false, &menu_assets);
-                    menu_item.insert(action);
-                    if action == LobbyMenuAction::StartMission {
-                        menu_item.insert(MissionLaunchControl);
-                    }
-                    menu_idx += 1;
+                // Always create all menu items for everyone (visibility controlled in update_display)
+                let mut menu_item =
+                    templates::create_menu_item(s, label, menu_idx, false, &menu_assets);
+                menu_item.insert(action);
+                if action == LobbyMenuAction::StartMission {
+                    menu_item.insert(MissionLaunchControl);
                 }
+                menu_idx += 1;
             }
 
             s.spawn((
@@ -259,6 +256,8 @@ pub(crate) fn setup_ui(
                     position_type: PositionType::Absolute,
                     right: Val::Px(40.0 * UI_SCALE),
                     top: Val::Px(40.0 * UI_SCALE),
+                    flex_direction: FlexDirection::Column,
+                    align_items: AlignItems::FlexEnd,
                     ..default()
                 },
                 LobbyRoomCode,
@@ -272,6 +271,17 @@ pub(crate) fn setup_ui(
                         ..default()
                     },
                     TextColor(colors::MENU_ITEM_COLOR_ON),
+                ));
+
+                parent.spawn((
+                    LobbyVersionWarning,
+                    Text::new(""),
+                    TextFont {
+                        font: menu_assets.font_titillium_regular.clone(),
+                        font_size: 16.0 * FONT_SCALE,
+                        ..default()
+                    },
+                    TextColor(Color::srgb(1.0, 0.5, 0.0)), // Orange
                 ));
             });
         }
@@ -428,19 +438,21 @@ pub(crate) struct LobbyUpdateParams<'w, 's> {
     pub q_lobby: Query<'w, 's, Ref<'static, LobbyInfo>>,
     pub q_selected_mission: Query<'w, 's, Entity, With<SelectedMission>>,
     pub auto_join_armed: Option<Res<'w, MissionAutoJoinArmed>>,
+    pub hub_conn_status: Option<Res<'w, unhub_plugin::hub_client::HubConnectionStatus>>,
 }
 
 pub(crate) fn update_display(
     params: LobbyUpdateParams,
     menu_assets: Option<Res<MenuAssets>>,
     mut q_preview: Query<&mut ImageNode, With<LobbyMapPreview>>,
-    mut q_map_info: Query<&mut Text, (With<LobbyMapInfo>, Without<LobbyDifficultyInfo>)>,
-    mut q_diff_info: Query<&mut Text, (With<LobbyDifficultyInfo>, Without<LobbyMapInfo>)>,
+    mut q_map_info: Query<&mut Text, (With<LobbyMapInfo>, Without<LobbyDifficultyInfo>, Without<LobbyVersionWarning>)>,
+    mut q_diff_info: Query<&mut Text, (With<LobbyDifficultyInfo>, Without<LobbyMapInfo>, Without<LobbyVersionWarning>)>,
     q_player_list: Query<Entity, With<LobbyPlayerList>>,
     q_children: Query<&Children>,
     mut commands: Commands,
     mut q_menu_items: Query<(&LobbyMenuAction, &mut Visibility, &Children)>,
-    mut q_text: Query<&mut Text, (Without<LobbyMapInfo>, Without<LobbyDifficultyInfo>)>,
+    mut q_text: Query<&mut Text, (Without<LobbyMapInfo>, Without<LobbyDifficultyInfo>, Without<LobbyVersionWarning>)>,
+    mut q_warning: Query<&mut Text, With<LobbyVersionWarning>>,
 ) {
     let Some(ui_assets) = menu_assets else {
         return;
@@ -506,7 +518,7 @@ pub(crate) fn update_display(
                 }
             }
             LobbyMenuAction::SelectMap | LobbyMenuAction::SelectDifficulty => {
-                if host_in_mission {
+                if host_in_mission || !is_room_owner {
                     *vis = Visibility::Hidden;
                 } else {
                     *vis = Visibility::Inherited;
@@ -516,12 +528,39 @@ pub(crate) fn update_display(
         }
     }
 
+    // Update Version Warning
+    if let Ok(mut warning_text) = q_warning.single_mut() {
+        let warning = if let Some(hub_status) = params.hub_conn_status.as_ref() {
+            match hub_status.status {
+                Some(unhub_client::protocol::MultiplayerStatus::UpdateAvailable) => {
+                    "Warning: Update available".to_string()
+                }
+                Some(unhub_client::protocol::MultiplayerStatus::UpdateRecommended) => {
+                    "Warning: Update recommended for compatibility".to_string()
+                }
+                Some(unhub_client::protocol::MultiplayerStatus::Unsupported) => {
+                    "CRITICAL: Version incompatible".to_string()
+                }
+                Some(unhub_client::protocol::MultiplayerStatus::Conflict) => {
+                    "CRITICAL: Version conflict detected".to_string()
+                }
+                _ => "".to_string(),
+            }
+        } else {
+            "".to_string()
+        };
+        if warning_text.0 != warning {
+            warning_text.0 = warning;
+        }
+    }
+
     if lobby_info
         .as_ref()
         .map(|li| !li.is_changed())
         .unwrap_or(true)
         && !params.maps.is_changed()
         && !params.local_player.is_changed()
+        && !params.hub_conn_status.is_some_and(|s| s.is_changed())
     {
         return;
     }


### PR DESCRIPTION
This PR implements several improvements to the multiplayer lobby and connection flow:
1. Fixes the issue where leadership buttons would not appear until a refresh when a player became the leader.
2. Displays Hub connection errors directly on the UI in orange, persisting for 10 seconds.
3. Implements client-side sending and server-side verification of the Replicon protocol hash during the join room request.
4. Adds a persistent version incompatibility warning in the Lobby UI based on Hub status.

---
*PR created automatically by Jules for task [3381729520994136338](https://jules.google.com/task/3381729520994136338) started by @deavid*