### PR TITLE
Fix auto-re-push and add cooldown to truck hold buttons

### DIFF
--- a/crates/untruck-core/src/components/truck_ui_button.rs
+++ b/crates/untruck-core/src/components/truck_ui_button.rs
@@ -25,6 +25,10 @@ pub struct TruckUIButton {
     pub frame_counter: u32,
     /// Whether the button is locked computer side, meaning it has a value already that cannot be changed anymore.
     pub computer_locked: bool,
+    /// Cooldown timer in seconds after activation
+    pub cooldown_timer: f32,
+    /// Whether the button requires a release before it can be pressed again
+    pub require_release: bool,
 }
 
 impl TruckUIButton {
@@ -72,6 +76,8 @@ impl From<TruckButtonType> for TruckUIButton {
             blinking_hint_active: false,
             frame_counter: 0,
             computer_locked: false,
+            cooldown_timer: 0.0,
+            require_release: false,
         }
     }
 }

--- a/crates/untruckui-plugin/src/systems.rs
+++ b/crates/untruckui-plugin/src/systems.rs
@@ -41,6 +41,14 @@ fn keyboard(
     }
 }
 
+fn truck_button_cooldown_system(time: Res<Time>, mut q_button: Query<&mut TruckUIButton>) {
+    for mut button in &mut q_button {
+        if button.cooldown_timer > 0.0 {
+            button.cooldown_timer = (button.cooldown_timer - time.delta_secs()).max(0.0);
+        }
+    }
+}
+
 fn hold_button_system(
     mut commands: Commands,
     time: Res<Time>,
@@ -70,6 +78,11 @@ fn hold_button_system(
             continue;
         }
 
+        // Gating: reset require_release when button is not pressed
+        if *interaction != Interaction::Pressed {
+            button.require_release = false;
+        }
+
         // Skip disabled buttons
         if button.disabled {
             continue;
@@ -92,6 +105,20 @@ fn hold_button_system(
 
         match *interaction {
             Interaction::Pressed => {
+                // Cooldown and gating check
+                if button.cooldown_timer > 0.0 || button.require_release {
+                    if button.holding {
+                        button.holding = false;
+                        button.hold_timer = None;
+                        if let Some(entity) = hold_sound.take() {
+                            if let Ok(mut cmd_e) = commands.get_entity(entity) {
+                                cmd_e.despawn();
+                            }
+                        }
+                    }
+                    continue;
+                }
+
                 if !button.holding {
                     // Start holding
                     button.holding = true;
@@ -191,6 +218,17 @@ fn hold_button_system(
                             _ => {}
                         }
 
+                        // Activate cooldown and require release
+                        button.cooldown_timer = 1.0;
+                        button.require_release = true;
+
+                        // Stop sound
+                        if let Some(entity) = hold_sound.take() {
+                            if let Ok(mut cmd_e) = commands.get_entity(entity) {
+                                cmd_e.despawn();
+                            }
+                        }
+
                         // Reset button state
                         button.holding = false;
                         button.hold_timer = None;
@@ -205,10 +243,10 @@ fn hold_button_system(
                     button.hold_timer = None;
 
                     // Stop sound
-                    if let Some(entity) = hold_sound.take()
-                        && let Ok(mut cmd_e) = commands.get_entity(entity)
-                    {
-                        cmd_e.despawn();
+                    if let Some(entity) = hold_sound.take() {
+                        if let Ok(mut cmd_e) = commands.get_entity(entity) {
+                            cmd_e.despawn();
+                        }
                     }
                 }
             }
@@ -294,6 +332,7 @@ pub(crate) fn app_setup(app: &mut App) {
     app.add_systems(
         Update,
         (
+            truck_button_cooldown_system,
             hold_button_system,
             update_craft_button_text,
             update_end_mission_button_status,


### PR DESCRIPTION
This change addresses the issue where "press & hold" buttons in the truck (Craft Repellent and End Mission) would immediately re-trigger if the user didn't release the button fast enough.

Key changes:
1. **TruckUIButton Component**: Added `cooldown_timer` (f32) and `require_release` (bool) to track the state of each button.
2. **Cooldown System**: A new `truck_button_cooldown_system` runs during the truck state to decrement active cooldown timers.
3. **Hold Logic Gating**: `hold_button_system` now checks if a button is in cooldown or requires a release before starting or continuing a hold interaction.
4. **Activation Feedback**: Upon successful hold completion, the button enters a 1-second cooldown and sets `require_release` to true. The hold sound is stopped immediately.
5. **Robustness**: Replaced unstable let-chains with standard Rust syntax and fixed Bevy `commands.get_entity` usage to ensure compatibility with the stable toolchain and Bevy 0.18.

---
*PR created automatically by Jules for task [10668448486101914702](https://jules.google.com/task/10668448486101914702) started by @deavid*