### PR TITLE
Fix B23 Flashlight Overheat Sound Spam & Document B22 Findings

### DIFF
--- a/crates/unaudiospatial-plugin/src/plugin.rs
+++ b/crates/unaudiospatial-plugin/src/plugin.rs
@@ -17,7 +17,8 @@ impl Plugin for UnhaunterSpatialAudioPlugin {
         if self.enable {
             app.add_systems(
                 Update,
-                spatial_audio_playback.run_if(in_state(UIContextState::InGame)),
+                (spatial_audio_playback, monitor_audio_pileup)
+                    .run_if(in_state(UIContextState::InGame)),
             );
         }
 

--- a/crates/unaudiospatial-plugin/src/systems.rs
+++ b/crates/unaudiospatial-plugin/src/systems.rs
@@ -111,14 +111,27 @@ pub fn spatial_audio_playback(
 pub fn monitor_audio_pileup(
     q_audio_players: Query<&AudioPlayer<AudioSource>>,
     time: Res<Time>,
+    asset_server: Res<AssetServer>,
     mut last_warn: Local<f32>,
 ) {
     let count = q_audio_players.iter().count();
     let now = time.elapsed_secs();
-    if count > 100 && now - *last_warn > 1.0 {
+    if count > 20 && now - *last_warn > 1.0 {
+        let mut counts: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::default();
+        for player in q_audio_players.iter() {
+            let path = asset_server
+                .get_path(&player.0)
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            *counts.entry(path).or_insert(0) += 1;
+        }
+        let mut details: Vec<_> = counts.into_iter().collect();
+        details.sort_by(|a, b| b.1.cmp(&a.1));
+
         warn!(
-            "AUDIO PILEUP: {} active AudioPlayer entities detected!",
-            count
+            "AUDIO PILEUP: {} active AudioPlayer entities detected! Details: {:?}",
+            count, details
         );
         *last_warn = now;
     }

--- a/crates/unaudiospatial-plugin/src/systems.rs
+++ b/crates/unaudiospatial-plugin/src/systems.rs
@@ -107,3 +107,19 @@ pub fn spatial_audio_playback(
     }
     measure.end_ms();
 }
+
+pub fn monitor_audio_pileup(
+    q_audio_players: Query<&AudioPlayer<AudioSource>>,
+    time: Res<Time>,
+    mut last_warn: Local<f32>,
+) {
+    let count = q_audio_players.iter().count();
+    let now = time.elapsed_secs();
+    if count > 100 && now - *last_warn > 1.0 {
+        warn!(
+            "AUDIO PILEUP: {} active AudioPlayer entities detected!",
+            count
+        );
+        *last_warn = now;
+    }
+}

--- a/crates/ungearitems-core/src/components/flashlight.rs
+++ b/crates/ungearitems-core/src/components/flashlight.rs
@@ -46,6 +46,8 @@ pub struct FlashlightSkin {
     pub frame_counter: u8,
     pub rand: u8,
     pub output_power: f32,
+    /// Local flag to ensure the overheat sound only plays once per overheat event.
+    pub overheat_sound_played: bool,
 }
 
 impl Default for FlashlightSkin {
@@ -56,6 +58,7 @@ impl Default for FlashlightSkin {
             frame_counter: Default::default(),
             rand: Default::default(),
             output_power: 0.0,
+            overheat_sound_played: false,
         }
     }
 }

--- a/crates/ungearitems-plugin/src/components/flashlight.rs
+++ b/crates/ungearitems-plugin/src/components/flashlight.rs
@@ -125,7 +125,13 @@ pub(crate) fn update_flashlight_skin(
                 if locally_owned.is_some() {
                     flashlight.status = FlashlightStatus::Off;
                 }
-                ga.play_audio("sounds/effects-dingdingding.ogg".into(), 0.7, pos);
+                if !skin.overheat_sound_played {
+                    ga.play_audio("sounds/effects-dingdingding.ogg".into(), 0.7, pos);
+                    skin.overheat_sound_played = true;
+                }
+            }
+            if skin.inner_temp < 0.95 || flashlight.status == FlashlightStatus::Off {
+                skin.overheat_sound_played = false;
             }
         }
 

--- a/docs/bug_investigation/B22.md
+++ b/docs/bug_investigation/B22.md
@@ -42,4 +42,4 @@
 - **Generic Pattern**: Gear items are registered in `crates/ungearitems-plugin/src/registration.rs` with closures that insert simulation components (like `EMFMeter`, `GeigerCounter`, `FlashlightSkin`) on all clients. The corresponding update systems then drive visuals AND audio locally for all such entities.
 
 ### Monitoring System
-To aid in diagnosing future pileups, a `monitor_audio_pileup` system has been added to `unaudiospatial-plugin`. It logs a warning if more than 100 `AudioPlayer` entities are active simultaneously. This threshold can be adjusted if found to be too sensitive for normal high-activity gameplay.
+To aid in diagnosing future pileups, a `monitor_audio_pileup` system has been added to `unaudiospatial-plugin`. It logs a warning if more than 20 `AudioPlayer` entities are active simultaneously, along with the counts of specific sound files being played.

--- a/docs/bug_investigation/B22.md
+++ b/docs/bug_investigation/B22.md
@@ -17,4 +17,26 @@
 
 ## Findings
 
-- TBD
+### Facts
+- Many gear items (Flashlight, EMF Meter, Geiger Counter, etc.) use a "skin" component for local simulation and visual/audio effects.
+- These "skin" components are added to gear entities on all clients, not just the owner (see `hydrate_flashlight_skin` and others in `ungearitems-plugin`).
+- Logic that triggers sounds (e.g., EMF chirps, Geiger clicks, Flashlight overheat) often lives in systems that run on all clients with `LocalPlayerRole`.
+- Because `SoundEvent` is a local message (it is NOT replicated), each client triggers the sound locally based on its own simulation of the gear's "skin".
+- Small variances in frame timing and float math across different clients cause these "simultaneous" sounds to trigger at slightly different times, creating an echo/chorus effect.
+- In a session with 4 players, if one player's gear triggers a sound, all 4 players simulate that gear and all 4 trigger the sound locally, leading to 4x sound instances for every event.
+
+### Theories
+- FPS drops are likely a direct result of the `AudioPlayer` entity pileup. If multiple players' gear items are all "multiplying" their sounds, the total number of active audio entities can grow exponentially.
+- The `PlayPositionalSoundBroadcast` approach mentioned in B09 was likely intended to solve this by making the authority the sole source of truth for sounds, but it was reverted because `SoundEvent` is a local message and couldn't be easily broadcast without a wrapper.
+
+### Related Files and Types
+- `crates/ungearitems-plugin/src/components/emfmeter.rs`: `update_emfmeter` triggers "sounds/effects-chirp-shorter.ogg" and glitch sounds based on local `EMFMeter` and `Electronic` state.
+- `crates/ungearitems-plugin/src/components/geigercounter.rs`: `update_geigercounter` triggers "sounds/effects-chirp-click.ogg" or "sounds/effects-chirp-short.ogg" based on local `GeigerCounter` simulation.
+- `crates/ungearitems-plugin/src/components/flashlight.rs`: `update_flashlight_skin` triggers "sounds/effects-dingdingding.ogg" on overheat.
+- `crates/unaudiospatial-plugin/src/systems.rs`: `spatial_audio_playback` (processes `SoundEvent`).
+- `crates/unaudiospatial-core/src/events.rs`: `SoundEvent` (struct).
+
+### Specific Findings in Code
+- **EMF Meter**: The `update_emfmeter` system runs on all clients with `LocalPlayerRole`. It calculates `emf.emf` locally by sampling replicated board fields. It then calls `gs_audio.play_audio` when a timer expires. Since every client does this for every EMF meter in the world, a single meter's chirps are multiplied by the number of players.
+- **Geiger Counter**: Similar to the EMF Meter, `update_geigercounter` simulates the counter's state locally on all clients and triggers audio clicks independently.
+- **Generic Pattern**: Gear items are registered in `crates/ungearitems-plugin/src/registration.rs` with closures that insert simulation components (like `EMFMeter`, `GeigerCounter`, `FlashlightSkin`) on all clients. The corresponding update systems then drive visuals AND audio locally for all such entities.

--- a/docs/bug_investigation/B22.md
+++ b/docs/bug_investigation/B22.md
@@ -40,3 +40,6 @@
 - **EMF Meter**: The `update_emfmeter` system runs on all clients with `LocalPlayerRole`. It calculates `emf.emf` locally by sampling replicated board fields. It then calls `gs_audio.play_audio` when a timer expires. Since every client does this for every EMF meter in the world, a single meter's chirps are multiplied by the number of players.
 - **Geiger Counter**: Similar to the EMF Meter, `update_geigercounter` simulates the counter's state locally on all clients and triggers audio clicks independently.
 - **Generic Pattern**: Gear items are registered in `crates/ungearitems-plugin/src/registration.rs` with closures that insert simulation components (like `EMFMeter`, `GeigerCounter`, `FlashlightSkin`) on all clients. The corresponding update systems then drive visuals AND audio locally for all such entities.
+
+### Monitoring System
+To aid in diagnosing future pileups, a `monitor_audio_pileup` system has been added to `unaudiospatial-plugin`. It logs a warning if more than 100 `AudioPlayer` entities are active simultaneously. This threshold can be adjusted if found to be too sensitive for normal high-activity gameplay.

--- a/docs/bug_investigation/B23.md
+++ b/docs/bug_investigation/B23.md
@@ -15,4 +15,18 @@
 
 ## Findings
 
-- TBD
+### Facts
+- The flashlight overheat sound is triggered in `update_flashlight_skin` (`crates/ungearitems-plugin/src/components/flashlight.rs`) when `skin.inner_temp > 1.0` and `flashlight.status != FlashlightStatus::Off`.
+- `FlashlightSkin` is a local component (not replicated) that exists on every client that can see the flashlight.
+- Every client simulates `inner_temp` independently for every flashlight in the scene.
+- When a flashlight overheats, only the owner can set `flashlight.status = FlashlightStatus::Off`.
+- For all other clients, `flashlight.status` remains active until the owner's change is replicated back to them.
+- This creates a window (the network round-trip time) where `inner_temp > 1.0` and `status != Off` are both true on non-owner clients, causing `ga.play_audio` to be called every single frame.
+
+### Theories
+- The "ding ding ding" sound effect itself might be long enough that hundreds of instances are playing simultaneously, leading to the reported overwhelming audio and potentially contributing to FPS drops.
+
+### Related Files and Types
+- `crates/ungearitems-plugin/src/components/flashlight.rs`: `update_flashlight_skin` (system)
+- `crates/ungearitems-core/src/components/flashlight.rs`: `FlashlightStatus` (enum), `Flashlight` (component), `FlashlightSkin` (component)
+- `crates/unaudiospatial-core/src/emitter.rs`: `AudioEmitter` (SystemParam used to play the sound)


### PR DESCRIPTION
This PR addresses the flashlight overheat sound spam bug (B23) and provides documentation for the audio multiplication investigation (B22).

### Changes
- **Flashlight Fix (B23)**: Added an `overheat_sound_played` boolean to `FlashlightSkin` in `unhaunter_gearitems_core`. The `update_flashlight_skin` system in `ungearitems-plugin` now uses this flag to ensure the "ding ding ding" sound triggers exactly once when a flashlight overheats. The flag is reset once the flashlight cools down below 0.95 or is turned off.
- **Documentation**: Updated `docs/bug_investigation/B22.md` and `B23.md` with Facts and Theories derived from the codebase investigation.

### Bug B22 Investigation Summary
The echoing and FPS drops reported in B22 are caused by "skin" components being simulated on all clients. When gear triggers a local `SoundEvent` (like an EMF chirp or Geiger click), every client in the session triggers that same sound locally for that specific entity, leading to multiplication proportional to the number of players.

### Bug B23 Investigation Summary
The overheat sound spammed per-frame because non-owner clients continued to simulate the flashlight's temperature while waiting for the owner's `FlashlightStatus::Off` state change to replicate back, repeatedly hitting the trigger condition.

---
*PR created automatically by Jules for task [6434177502424542068](https://jules.google.com/task/6434177502424542068) started by @deavid*