### PR TITLE
Implement Player Name Labels with Visibility Gating

### DIFF
--- a/crates/unclassic-mode-render-plugin/src/lib.rs
+++ b/crates/unclassic-mode-render-plugin/src/lib.rs
@@ -6,5 +6,6 @@
 pub(crate) mod camera;
 pub(crate) mod cleanup;
 pub(crate) mod hydration;
+pub(crate) mod player_names;
 
 pub mod plugin;

--- a/crates/unclassic-mode-render-plugin/src/player_names.rs
+++ b/crates/unclassic-mode-render-plugin/src/player_names.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 use uninput_core::components::PlayerInput;
+use unplayer_core::colors;
 use unplayer_core::components::{MainPlayer, PlayerNameLabel, PlayerSprite};
+use unreplicon_core::components::LobbyInfo;
 use unreplicon_core::identity::generate_deterministic_name;
 use unspatial_core::position::Position;
 
@@ -11,14 +13,18 @@ struct PlayerNameLabelHydrated;
 fn hydrate_player_name_system(
     mut commands: Commands,
     q_players: Query<(Entity, &PlayerSprite), Without<PlayerNameLabelHydrated>>,
+    asset_server: Res<AssetServer>,
 ) {
     for (entity, player_sprite) in q_players.iter() {
         let name = generate_deterministic_name(player_sprite.id);
+        let font_handle = asset_server.load("fonts/overlock/Overlock-Regular.ttf");
+
         commands.entity(entity).with_children(|parent| {
             parent
                 .spawn((
                     Text2d::new(name),
                     TextFont {
+                        font: font_handle,
                         font_size: 16.0,
                         ..default()
                     },
@@ -38,18 +44,21 @@ fn hydrate_player_name_system(
 
 fn update_player_name_visibility_system(
     q_main_player: Query<(Entity, &Position, &PlayerInput), With<MainPlayer>>,
-    q_other_players: Query<(Entity, &Position), (With<PlayerSprite>, Without<MainPlayer>)>,
-    mut q_labels: Query<(&ChildOf, &mut Visibility), With<PlayerNameLabel>>,
+    q_other_players: Query<(Entity, &Position, &PlayerSprite), Without<MainPlayer>>,
+    mut q_labels: Query<(&ChildOf, &mut Visibility, &mut TextColor), With<PlayerNameLabel>>,
+    q_all_players: Query<&PlayerSprite>,
+    q_lobby: Query<&LobbyInfo>,
 ) {
     let Ok((main_entity, main_pos, main_input)) = q_main_player.single() else {
         return;
     };
 
+    let lobby_info = q_lobby.single().ok();
     let aim_dir = main_input.aim_direction.normalize_or_zero();
 
     let mut best_target: Option<(Entity, f32)> = None;
 
-    for (entity, pos) in q_other_players.iter() {
+    for (entity, pos, _sprite) in q_other_players.iter() {
         let delta = pos.delta(*main_pos);
         let dist = delta.distance();
         if dist > 8.0 {
@@ -72,14 +81,39 @@ fn update_player_name_visibility_system(
         }
     }
 
-    for (parent, mut visibility) in q_labels.iter_mut() {
-        if parent.parent() == main_entity {
+    for (child_of, mut visibility, mut text_color) in q_labels.iter_mut() {
+        let parent_entity = child_of.parent();
+        let Ok(ps) = q_all_players.get(parent_entity) else {
+            continue;
+        };
+
+        // Update color based on player tint
+        let fallback_tint = ps.network_id.0 as usize % 9;
+        let tint_index = lobby_info
+            .and_then(|li| {
+                li.players
+                    .iter()
+                    .find(|p| p.player_uuid == ps.id)
+                    .map(|p| p.tint_color_index as usize)
+            })
+            .unwrap_or(fallback_tint);
+
+        let mut color = colors::player_color(tint_index);
+
+        // Brighten the color for better visibility as text
+        if let Color::Hsla(mut hsla) = color {
+            hsla.lightness = (hsla.lightness * 1.5).min(1.0);
+            color = Color::Hsla(hsla);
+        }
+        text_color.0 = color;
+
+        if parent_entity == main_entity {
             *visibility = Visibility::Inherited;
             continue;
         }
 
         if let Some((target_entity, _)) = best_target {
-            if parent.parent() == target_entity {
+            if parent_entity == target_entity {
                 *visibility = Visibility::Inherited;
             } else {
                 *visibility = Visibility::Hidden;

--- a/crates/unclassic-mode-render-plugin/src/player_names.rs
+++ b/crates/unclassic-mode-render-plugin/src/player_names.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use bevy::sprite::Text2dShadow;
 use uninput_core::components::PlayerInput;
 use unplayer_core::colors;
 use unplayer_core::components::{MainPlayer, PlayerNameLabel, PlayerSprite};
@@ -12,12 +13,38 @@ struct PlayerNameLabelHydrated;
 
 fn hydrate_player_name_system(
     mut commands: Commands,
-    q_players: Query<(Entity, &PlayerSprite), Without<PlayerNameLabelHydrated>>,
+    q_players: Query<(Entity, &PlayerSprite, &Transform), Without<PlayerNameLabelHydrated>>,
     asset_server: Res<AssetServer>,
 ) {
-    for (entity, player_sprite) in q_players.iter() {
+    for (entity, player_sprite, player_transform) in q_players.iter() {
         let name = generate_deterministic_name(player_sprite.id);
         let font_handle = asset_server.load("fonts/overlock/Overlock-Regular.ttf");
+
+        // Player visuals are scaled during hydration (typically by 1.0 / player_rf).
+        // Compensate here so label size/offset stay stable regardless of parent scale.
+        let inverse_parent_scale = Vec3::new(
+            if player_transform.scale.x.abs() > f32::EPSILON {
+                1.0 / player_transform.scale.x
+            } else {
+                1.0
+            },
+            if player_transform.scale.y.abs() > f32::EPSILON {
+                1.0 / player_transform.scale.y
+            } else {
+                1.0
+            },
+            if player_transform.scale.z.abs() > f32::EPSILON {
+                1.0 / player_transform.scale.z
+            } else {
+                1.0
+            },
+        );
+        let label_offset = Vec3::new(0.0, -2.0, 0.01);
+        let compensated_offset = Vec3::new(
+            label_offset.x * inverse_parent_scale.x,
+            label_offset.y * inverse_parent_scale.y,
+            label_offset.z * inverse_parent_scale.z,
+        );
 
         commands.entity(entity).with_children(|parent| {
             parent
@@ -25,15 +52,23 @@ fn hydrate_player_name_system(
                     Text2d::new(name),
                     TextFont {
                         font: font_handle,
-                        font_size: 16.0,
+                        font_size: 21.0,
                         ..default()
                     },
-                    TextColor(Color::WHITE),
+                    TextColor(Color::WHITE.with_alpha(0.5)),
+                    Text2dShadow {
+                        color: Color::BLACK.with_alpha(0.5),
+                        offset: Vec2::new(1.5, -1.5),
+                    },
                     PlayerNameLabel,
                     // Position it below the character's feet.
                     // The character anchor is roughly (0.0, -0.4) in normalized sprite coords.
                     // In screen pixels it depends on rf, but (0, -18, 0.01) is a decent start.
-                    Transform::from_xyz(0.0, -18.0, 0.01),
+                    Transform {
+                        translation: compensated_offset,
+                        scale: inverse_parent_scale / 6.0,
+                        ..default()
+                    },
                     Visibility::Hidden,
                 ))
                 .insert(bevy::sprite::Anchor(Vec2::new(0.0, 0.5))); // TopCenter
@@ -127,7 +162,10 @@ fn update_player_name_visibility_system(
 pub(crate) fn app_setup(app: &mut App) {
     app.add_systems(
         Update,
-        (hydrate_player_name_system, update_player_name_visibility_system)
+        (
+            hydrate_player_name_system,
+            update_player_name_visibility_system,
+        )
             .run_if(in_state(uncommon_states_core::UIContextState::InGame)),
     );
 }

--- a/crates/unclassic-mode-render-plugin/src/player_names.rs
+++ b/crates/unclassic-mode-render-plugin/src/player_names.rs
@@ -1,0 +1,99 @@
+use bevy::prelude::*;
+use uninput_core::components::PlayerInput;
+use unplayer_core::components::{MainPlayer, PlayerNameLabel, PlayerSprite};
+use unreplicon_core::identity::generate_deterministic_name;
+use unspatial_core::position::Position;
+
+/// Marker for the hydrated player name label.
+#[derive(Component)]
+struct PlayerNameLabelHydrated;
+
+fn hydrate_player_name_system(
+    mut commands: Commands,
+    q_players: Query<(Entity, &PlayerSprite), Without<PlayerNameLabelHydrated>>,
+) {
+    for (entity, player_sprite) in q_players.iter() {
+        let name = generate_deterministic_name(player_sprite.id);
+        commands.entity(entity).with_children(|parent| {
+            parent
+                .spawn((
+                    Text2d::new(name),
+                    TextFont {
+                        font_size: 16.0,
+                        ..default()
+                    },
+                    TextColor(Color::WHITE),
+                    PlayerNameLabel,
+                    // Position it below the character's feet.
+                    // The character anchor is roughly (0.0, -0.4) in normalized sprite coords.
+                    // In screen pixels it depends on rf, but (0, -18, 0.01) is a decent start.
+                    Transform::from_xyz(0.0, -18.0, 0.01),
+                    Visibility::Hidden,
+                ))
+                .insert(bevy::sprite::Anchor(Vec2::new(0.0, 0.5))); // TopCenter
+        });
+        commands.entity(entity).insert(PlayerNameLabelHydrated);
+    }
+}
+
+fn update_player_name_visibility_system(
+    q_main_player: Query<(Entity, &Position, &PlayerInput), With<MainPlayer>>,
+    q_other_players: Query<(Entity, &Position), (With<PlayerSprite>, Without<MainPlayer>)>,
+    mut q_labels: Query<(&ChildOf, &mut Visibility), With<PlayerNameLabel>>,
+) {
+    let Ok((main_entity, main_pos, main_input)) = q_main_player.single() else {
+        return;
+    };
+
+    let aim_dir = main_input.aim_direction.normalize_or_zero();
+
+    let mut best_target: Option<(Entity, f32)> = None;
+
+    for (entity, pos) in q_other_players.iter() {
+        let delta = pos.delta(*main_pos);
+        let dist = delta.distance();
+        if dist > 8.0 {
+            continue;
+        }
+        let dir = Vec2::new(delta.dx, delta.dy).normalize_or_zero();
+        let dot = aim_dir.dot(dir);
+
+        // Score based on aiming (dot product) and proximity.
+        // Higher dot and lower distance result in a higher score.
+        if dot > 0.8 {
+            let score = dot / (dist + 1.0);
+            if let Some((_, best_score)) = best_target {
+                if score > best_score {
+                    best_target = Some((entity, score));
+                }
+            } else {
+                best_target = Some((entity, score));
+            }
+        }
+    }
+
+    for (parent, mut visibility) in q_labels.iter_mut() {
+        if parent.parent() == main_entity {
+            *visibility = Visibility::Inherited;
+            continue;
+        }
+
+        if let Some((target_entity, _)) = best_target {
+            if parent.parent() == target_entity {
+                *visibility = Visibility::Inherited;
+            } else {
+                *visibility = Visibility::Hidden;
+            }
+        } else {
+            *visibility = Visibility::Hidden;
+        }
+    }
+}
+
+pub(crate) fn app_setup(app: &mut App) {
+    app.add_systems(
+        Update,
+        (hydrate_player_name_system, update_player_name_visibility_system)
+            .run_if(in_state(uncommon_states_core::UIContextState::InGame)),
+    );
+}

--- a/crates/unclassic-mode-render-plugin/src/plugin.rs
+++ b/crates/unclassic-mode-render-plugin/src/plugin.rs
@@ -7,5 +7,6 @@ impl Plugin for ClassicModeRenderPlugin {
         crate::cleanup::app_setup(app);
         crate::hydration::app_setup(app);
         crate::camera::app_setup(app);
+        crate::player_names::app_setup(app);
     }
 }

--- a/crates/unplayer-core/src/components.rs
+++ b/crates/unplayer-core/src/components.rs
@@ -132,6 +132,10 @@ pub struct Hiding {
     pub hiding_spot: Option<Entity>,
 }
 
+/// Marker for the entity that displays the player's name label.
+#[derive(Component, Debug, Clone, Default)]
+pub struct PlayerNameLabel;
+
 impl bevy::ecs::entity::MapEntities for Hiding {
     fn map_entities<M: bevy::ecs::entity::EntityMapper>(&mut self, mapper: &mut M) {
         if let Some(ref mut h) = self.hiding_spot {


### PR DESCRIPTION
This PR implements player name labels for multiplayer missions. 

### Key Changes:
- **`PlayerNameLabel` Component**: A new marker component to identify name label entities.
- **Hydration System**: Automatically spawns a `Text2d` child for every player entity on the client. Names are deterministically generated from player UUIDs.
- **Visibility Gating**: 
    - The local player's own name is always shown.
    - Names of other players are only shown when looking towards them.
    - A scoring system selects the single "best" target based on how directly the local player is aiming at them and their proximity.
- **Positioning**: Labels are anchored to the ground contact point of the character and offset slightly downwards.
- **Bevy 0.18 Compatibility**: Adapted to modern Bevy patterns including decoupled text components, `ChildOf` hierarchy traversal, and tuple-struct `Anchor`.

### Verification:
- Verified code correctness with `cargo check`.
- Ensured no regressions in core identity or input logic.

---
*PR created automatically by Jules for task [15415970192405932976](https://jules.google.com/task/15415970192405932976) started by @deavid*