### PR TITLE
Ghost-Miasma-Player Interactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9464,6 +9464,7 @@ dependencies = [
  "unboard-core",
  "uncommon-states-core",
  "undifficulty-core",
+ "unfog-core",
  "unghost-core",
  "unlight-core",
  "unmission-core",

--- a/crates/unfog-plugin/src/systems.rs
+++ b/crates/unfog-plugin/src/systems.rs
@@ -17,6 +17,7 @@ use uncommon_app_core::random_seed;
 use unfog_core::components::MiasmaSprite;
 use unfog_core::miasma::MiasmaGrid;
 use unfog_core::resources::MiasmaConfig;
+use unghost_core::components::logic::ghost_sprite::GhostSprite;
 use unlight_core::components::LightSensitive;
 use unmetrics_core::metrics::SendMetric;
 use unmission_core::events::{LevelReadyEvent, MapGeometryInitializedEvent};
@@ -347,6 +348,7 @@ pub(crate) fn update_miasma(
     time: Res<Time>,
     room_topology: Res<RoomTopology>,
     q_player: Query<&Position, With<MainPlayer>>,
+    q_ghost: Query<(&Position, &GhostSprite)>,
     fluid_emitter_query: Query<&FluidEmitter>,
     mut room_present: Local<Array3<bool>>,
     video_settings: Res<Persistent<VideoSettings>>,
@@ -381,6 +383,15 @@ pub(crate) fn update_miasma(
     let Ok(player_pos) = q_player.single() else {
         return;
     };
+
+    // --- Ghost Influence: Source ---
+    for (g_pos, g_sprite) in q_ghost.iter() {
+        let g_bpos = g_pos.to_board_position();
+        let hunt_mult = if g_sprite.hunting > 0.0 { 25.0 } else { 1.0 };
+        if let Some(pressure) = miasma.pressure_field.get_mut(g_bpos.ndidx()) {
+            *pressure += 20.0 * dt * hunt_mult;
+        }
+    }
     let player_bpos = player_pos.to_board_position();
 
     // Iterate through chunks
@@ -596,11 +607,48 @@ pub(crate) fn update_miasma(
             let calc_vel_len = calculated_velocity.length() + 0.000001;
             let adjusted_vel = f32::cbrt(calc_vel_len).min(1.0);
             let calculated_velocity = calculated_velocity * (adjusted_vel / calc_vel_len); // .min(calculated_velocity);
+
+            let mut ghost_force = Vec2::ZERO;
+            for (g_pos, g_sprite) in q_ghost.iter() {
+                let pos_v = bpos.to_position_center();
+                let dist = pos_v.distance(g_pos);
+                let hunt_mult = if g_sprite.hunting > 0.0 { 25.0 } else { 1.0 };
+
+                // 2. Push away (~5 tiles)
+                if dist < 5.0 {
+                    let push_dir = (pos_v.to_vec3() - g_pos.to_vec3())
+                        .truncate()
+                        .normalize_or_zero();
+                    ghost_force += push_dir * (1.0 - dist / 5.0) * 0.5 * hunt_mult;
+                }
+
+                // 3. Movement/Warp push
+                if dist < 8.0 {
+                    let mut move_dir = Vec2::ZERO;
+                    if let Some(target) = g_sprite.target_point {
+                        move_dir = (target.to_vec3() - g_pos.to_vec3())
+                            .truncate()
+                            .normalize_or_zero();
+                    }
+                    let warp_mult = if g_sprite.warp > 0.0 { 10.0 } else { 2.0 };
+                    ghost_force += move_dir * (1.0 - dist / 8.0) * 0.5 * hunt_mult * warp_mult;
+                }
+
+                // 4. Attraction (>15 tiles)
+                if dist > 15.0 {
+                    let pull_dir = (g_pos.to_vec3() - pos_v.to_vec3())
+                        .truncate()
+                        .normalize_or_zero();
+                    ghost_force += pull_dir * 0.01 * hunt_mult;
+                }
+            }
+
             let previous_velocity = miasma.velocity_field[p];
 
             // FIXME: This should be proportional change of dt
             let mut new_velocity = (previous_velocity * miasma_config.inertia_factor
-                + calculated_velocity)
+                + calculated_velocity
+                + ghost_force)
                 / (1.0 + miasma_config.inertia_factor + miasma_config.friction);
 
             // Take walls into account.

--- a/crates/unfog-plugin/src/systems.rs
+++ b/crates/unfog-plugin/src/systems.rs
@@ -389,7 +389,7 @@ pub(crate) fn update_miasma(
         let g_bpos = g_pos.to_board_position();
         let hunt_mult = if g_sprite.hunting > 0.0 { 100.0 } else { 1.0 };
         if let Some(pressure) = miasma.pressure_field.get_mut(g_bpos.ndidx()) {
-            *pressure += 20.0 * dt * hunt_mult;
+            *pressure += 200.0 * dt * hunt_mult;
         }
     }
     let player_bpos = player_pos.to_board_position();

--- a/crates/unfog-plugin/src/systems.rs
+++ b/crates/unfog-plugin/src/systems.rs
@@ -651,6 +651,9 @@ pub(crate) fn update_miasma(
                 + ghost_force)
                 / (1.0 + miasma_config.inertia_factor + miasma_config.friction);
 
+            // Clamp velocity to a maximum of 1 tile per second to avoid "overflowing"
+            new_velocity = new_velocity.clamp_length_max(1.0);
+
             // Take walls into account.
             const WALL_REPEL_SPEED: f32 = 0.00;
             let old_speed = new_velocity.length();

--- a/crates/unfog-plugin/src/systems.rs
+++ b/crates/unfog-plugin/src/systems.rs
@@ -387,7 +387,7 @@ pub(crate) fn update_miasma(
     // --- Ghost Influence: Source ---
     for (g_pos, g_sprite) in q_ghost.iter() {
         let g_bpos = g_pos.to_board_position();
-        let hunt_mult = if g_sprite.hunting > 0.0 { 25.0 } else { 1.0 };
+        let hunt_mult = if g_sprite.hunting > 0.0 { 100.0 } else { 1.0 };
         if let Some(pressure) = miasma.pressure_field.get_mut(g_bpos.ndidx()) {
             *pressure += 20.0 * dt * hunt_mult;
         }
@@ -651,8 +651,8 @@ pub(crate) fn update_miasma(
                 + ghost_force)
                 / (1.0 + miasma_config.inertia_factor + miasma_config.friction);
 
-            // Clamp velocity to a maximum of 1 tile per second to avoid "overflowing"
-            new_velocity = new_velocity.clamp_length_max(1.0);
+            // Clamp velocity to a maximum of 2 tiles per second to avoid "overflowing"
+            new_velocity = new_velocity.clamp_length_max(2.0);
 
             // Take walls into account.
             const WALL_REPEL_SPEED: f32 = 0.00;

--- a/crates/unlocomotion-plugin/src/systems/mod.rs
+++ b/crates/unlocomotion-plugin/src/systems/mod.rs
@@ -263,16 +263,20 @@ pub(crate) fn apply_movement_intent(
 
         let wants_to_run = player_input.run;
 
-        let miasma_factor = if let Some(miasma) = miasma.as_ref() {
+        let miasma_pressure = if let Some(miasma) = miasma.as_ref() {
             let bpos = pos.to_board_position();
             miasma
                 .pressure_field
                 .get(bpos.ndidx())
-                .map(|pressure| (*pressure / 100.0).max(0.0).cbrt().clamp(0.0, 0.7))
+                .copied()
                 .unwrap_or(0.0)
         } else {
             0.0
         };
+
+        let miasma_factor = (miasma_pressure / 100.0).max(0.0).cbrt().clamp(0.0, 0.7);
+        let miasma_speed_penalty = ((miasma_pressure - 1000.0) / 9000.0).clamp(0.0, 0.6);
+        let miasma_speed_mult = 1.0 - miasma_speed_penalty;
 
         stamina.depletion_rate = miasma_factor;
         let is_running = stamina.update(dt, wants_to_run).cbrt();
@@ -293,10 +297,20 @@ pub(crate) fn apply_movement_intent(
             continue;
         }
 
-        let pdx =
-            PLAYER_SPEED * d.dx * dt * speed_penalty * difficulty.0.player_speed() * run_multiplier;
-        let pdy =
-            PLAYER_SPEED * d.dy * dt * speed_penalty * difficulty.0.player_speed() * run_multiplier;
+        let pdx = PLAYER_SPEED
+            * d.dx
+            * dt
+            * speed_penalty
+            * difficulty.0.player_speed()
+            * run_multiplier
+            * miasma_speed_mult;
+        let pdy = PLAYER_SPEED
+            * d.dy
+            * dt
+            * speed_penalty
+            * difficulty.0.player_speed()
+            * run_multiplier
+            * miasma_speed_mult;
 
         *avg_running = (*avg_running + is_running * dt) / (1.0 + dt);
 

--- a/crates/unlocomotion-plugin/src/systems/mod.rs
+++ b/crates/unlocomotion-plugin/src/systems/mod.rs
@@ -275,7 +275,7 @@ pub(crate) fn apply_movement_intent(
         };
 
         let miasma_factor = (miasma_pressure / 100.0).max(0.0).cbrt().clamp(0.0, 0.7);
-        let miasma_speed_penalty = ((miasma_pressure - 1000.0) / 9000.0).clamp(0.0, 0.6);
+        let miasma_speed_penalty = ((miasma_pressure - 1000.0) * (0.6 / 9000.0)).clamp(0.0, 0.6);
         let miasma_speed_mult = 1.0 - miasma_speed_penalty;
 
         stamina.depletion_rate = miasma_factor;

--- a/crates/unvitals-plugin/Cargo.toml
+++ b/crates/unvitals-plugin/Cargo.toml
@@ -26,3 +26,4 @@ unlight-core = { workspace = true }
 unboard-core = { workspace = true }
 untruck-core = { workspace = true }
 unthermal-core = { workspace = true }
+unfog-core = { workspace = true }

--- a/crates/unvitals-plugin/src/systems/other.rs
+++ b/crates/unvitals-plugin/src/systems/other.rs
@@ -6,13 +6,14 @@ use unplayer_core::components::{MainPlayer, PlayerSpectating, PlayerSprite};
 use unreplicon_core::ownership::LocallyOwned;
 use unspatial_core::position::Position;
 use untruck_core::components::in_truck::InTruck;
+use unfog_core::miasma::MiasmaGrid;
 use unvitals_core::components::{PlayerVitals, Stamina};
 use unvitals_core::events::PlayerDiedEvent;
 
 pub(crate) fn regenerate_health_over_time(
     time: Res<Time>,
     mut qp: Query<
-        &mut PlayerVitals,
+        (&mut PlayerVitals, &Position),
         (
             With<LocallyOwned>,
             Without<InTruck>,
@@ -20,12 +21,30 @@ pub(crate) fn regenerate_health_over_time(
         ),
     >,
     difficulty: Res<CurrentDifficulty>,
+    miasma: Option<Res<MiasmaGrid>>,
 ) {
     let dt = time.delta_secs();
-    for mut ps in &mut qp {
+    for (mut ps, pos) in &mut qp {
+        let miasma_pressure = if let Some(miasma) = miasma.as_ref() {
+            let bpos = pos.to_board_position();
+            miasma
+                .pressure_field
+                .get(bpos.ndidx())
+                .copied()
+                .unwrap_or(0.0)
+        } else {
+            0.0
+        };
+
+        // Prevent healing in very high miasma concentrations.
+        // Penalty starts at 1000 and completely stops healing at 10000.
+        let healing_penalty = ((miasma_pressure - 1000.0) / 9000.0).clamp(0.0, 1.0);
+        let healing_mult = 1.0 - healing_penalty;
+
         if ps.health < 100.0 && ps.health > 0.0 {
             ps.health += (0.1 * dt + (1.0 - ps.health / 100.0) * dt * 10.0)
-                * difficulty.0.health_recovery_rate();
+                * difficulty.0.health_recovery_rate()
+                * healing_mult;
         }
         if ps.health > 100.0 {
             ps.health = 100.0;

--- a/crates/unvitals-plugin/src/systems/sanity.rs
+++ b/crates/unvitals-plugin/src/systems/sanity.rs
@@ -80,7 +80,7 @@ pub(crate) fn drain_sanity_from_environment(
             let p_val = miasma.pressure_field.get(p).copied().unwrap_or(0.0);
             // Linear addition to crazyness starting at 1000 and reaching full intensity at 10000.
             // Full intensity is roughly 2.0 extra crazyness units per second (at default rate).
-            ((p_val - 1000.0) / 4500.0).max(0.0)
+            ((p_val - 1000.0) / 4500.0).clamp(0.0, 2.0)
         } else {
             0.0
         };

--- a/crates/unvitals-plugin/src/systems/sanity.rs
+++ b/crates/unvitals-plugin/src/systems/sanity.rs
@@ -4,6 +4,7 @@ use undifficulty_core::current_difficulty::CurrentDifficulty;
 use undifficulty_core::difficulty_settings::DifficultySettings;
 use unlight_core::resources::light_grid::LightGrid;
 use unplayer_core::components::{MainPlayer, PlayerSpectating};
+use unfog_core::miasma::MiasmaGrid;
 use unsoundfield_core::resources::SoundGrid;
 use unspatial_core::position::Position;
 use unthermal_core::resources::ThermalGrid;
@@ -29,6 +30,7 @@ pub(crate) fn drain_sanity_from_environment(
     thermal_grid: Option<Res<ThermalGrid>>,
     sound_grid: Option<Res<SoundGrid>>,
     lg: Option<Res<LightGrid>>,
+    miasma: Option<Res<MiasmaGrid>>,
     room_topology: Res<RoomTopology>,
     difficulty: Res<CurrentDifficulty>,
 ) {
@@ -73,9 +75,20 @@ pub(crate) fn drain_sanity_from_environment(
         } else {
             0.0
         };
+
+        let miasma_drain = if let Some(miasma) = miasma.as_ref() {
+            let p_val = miasma.pressure_field.get(p).copied().unwrap_or(0.0);
+            // Linear addition to crazyness starting at 1000 and reaching full intensity at 10000.
+            // Full intensity is roughly 2.0 extra crazyness units per second (at default rate).
+            ((p_val - 1000.0) / 4500.0).max(0.0)
+        } else {
+            0.0
+        };
+
         ps.crazyness +=
             (crazy.clamp(0.000000001, 10000000.0).sqrt() * 0.2 * difficulty.0.sanity_drain_rate()
-                - sanity_recover * ps.crazyness / (1.0 + ps.mean_sound * 10.0))
+                - sanity_recover * ps.crazyness / (1.0 + ps.mean_sound * 10.0)
+                + miasma_drain * difficulty.0.sanity_drain_rate())
                 * dt;
         if ps.crazyness < 0.0 {
             ps.crazyness = 0.0;

--- a/docs/bug_investigation/B19.md
+++ b/docs/bug_investigation/B19.md
@@ -18,4 +18,83 @@
 
 ## Findings
 
-- TBD
+### Solution Approach: Ghost-Miasma-Player Interactions (PR #205)
+
+**Approach**: Instead of directly buffing ghost damage, create environmental danger zones by coupling ghost behavior to
+the existing miasma simulation. High miasma areas become inherently dangerous to players.
+
+**Implementation** (May 12-13, 2026):
+
+#### Features Implemented:
+
+1. **Ghost as Miasma Source**: Ghosts emit miasma at their current position
+   - Base emission: 20 units/sec
+   - Hunt multiplier: **100x** when hunting
+
+2. **Ghost Pressure Forces** (within 8+ tile radius):
+   - **Push**: 5-tile repel when close (1.0 - dist/5.0) × hunt_mult
+   - **Movement**: Directional push toward target or warp destination (1.0 - dist/8.0) × hunt_mult
+   - **Attraction**: Slow pull from >15 tiles away
+
+3. **Player Penalties (scales with miasma pressure 1000→10000)**:
+   - Speed penalty: Linear 0→60% reduction
+   - Healing suppression: Regeneration stops at peak pressure
+   - Sanity drain: +2.0 crazyness/sec at peak pressure
+
+#### Status: **BLOCKED** by architectural review (5 comments)
+
+**✅ FIXED:**
+
+- Sanity drain formula: Unclamped past 10k → Added clamp(0.0, 2.0)
+- Speed penalty formula: Hit cap early (~6.4k) → Adjusted to linear ramp 1000→10000
+
+**⚠️ OPEN:**
+
+- Ghost pressure accumulation: Distant ghosts' pressure builds indefinitely with no diffusion until player approaches →
+  Need to constrain sources to processed chunks or add global decay
+- Performance: `q_ghost.iter()` called inside per-cell velocity loop = O(cells × ghosts) → Extract ghost data to Vec
+  once per frame
+
+**🚫 BLOCKING - Architecture violation:**
+
+- `unfog-plugin` directly reads `GhostSprite.hunting`, `GhostSprite.warp`, `GhostSprite.target_point` to drive fog
+  simulation. Violates **Tell-Don't-Ask** and domain boundaries.
+- Fix: Ghost domain must **emit signals** that fog listens to, not fog reaching into ghost internals. Consider:
+  dedicated `MiasmaInfluence` component or extend `FluidEmitter` system
+
+**Blocker Details** (from reviewer):
+
+> "`unfog-plugin` is now directly interpreting `GhostSprite` internals to drive the fog simulation. This couples the fog
+> domain to ghost AI state and duplicates ghost semantics outside the ghost domain... Consider having the ghost domain
+> emit a dedicated miasma-influence signal/component."
+
+**Next Steps to Merge**:
+
+1. Fix performance: pre-collect ghost data (Position + influence params) into Vec
+2. Fix accumulation: apply global decay/clamp or constrain sources to processed chunks
+3. **Fix architecture**: Refactor so ghost domain emits influence signals instead of fog querying ghost internals
+   - See: `docs/ECS_DOMAIN_MANIFESTO.md` (Tell-Don't-Ask)
+   - See: `docs/TOPOLOGY_BLEED_DOCTRINE.md` (marker-gated writes)
+
+#### Original request to Jules
+
+I would like to play around on Miasma reacting to the ghost, and Player reacting to Miasma. Also to tweak how hunts work
+so we have additional risks.
+
+1. Ghost is a source for miasma - like, we start the mission and the house is full of miasma, why? so we have a source
+   of miasma. Slow, but it would be easy to understand that over time it would fill the place.
+
+2. Ghost is a source for miasma pressure such that the miasma around it ~5 tiles is pushed away from the ghost.
+
+3. When the ghost moves, the miasma is pushed out more in the ghost direction. If the ghost warps, then the miasma is
+   pushed a lot into that warp direction.
+
+4. Miasma, when far away, is slowly attracted to the ghost. So anything >15 tiles feels a slight pull towards the ghost.
+
+5. When the ghost is hunting, these effects are cranked up to eleven. Normally they should be so slight that are hard to
+   notice. When hunting, they should be hard to ignore.
+
+6. The player movement would be restricted further by high miasma concentrations. And we're talking very high
+   concentrations only. And we need to ensure that we never penalize more than 60% of the speed.
+
+7. Very high miasma concentrations prevent player healing and they also make sanity decrease (players go crazy faster).


### PR DESCRIPTION
This PR implements a set of reactive interactions between ghosts, miasma, and players to increase mission dynamicism and risk.

Key features:
1. **Ghost as Miasma Source:** Ghosts now constantly emit miasma at their current position.
2. **Ghost Pressure:** Ghosts exert physical pressure on the miasma, pushing it away within 5 tiles and creating stronger directional pushes when moving or warping.
3. **Miasma Attraction:** Miasma at long ranges (>15 tiles) is slowly pulled towards the ghost's location.
4. **Hunt Multiplier:** All ghost-miasma interactions are scaled up by 25x during a hunt, making the effects much more pronounced.
5. **Player Speed Penalty:** High miasma concentrations (1,000 to 10,000 units) now apply a linear speed penalty to players, capping at a 60% reduction.
6. **Healing Suppression:** Automatic health regeneration is slowed and eventually stopped in high miasma concentrations.
7. **Sanity Drain:** Players experience increased 'crazyness' (sanity drain) when standing in thick miasma.

These changes are simulated locally on the client to ensure responsiveness.

---
*PR created automatically by Jules for task [8834350911250949294](https://jules.google.com/task/8834350911250949294) started by @deavid*