### PR TITLE
Shared Truck and Gear interaction sounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7960,8 +7960,10 @@ dependencies = [
  "unaudiospatial-core",
  "uncommon-states-core",
  "unmetrics-core",
+ "unreplicon-core",
  "unsettings-core",
  "unspatial-core",
+ "untruck-core",
 ]
 
 [[package]]
@@ -8313,6 +8315,7 @@ dependencies = [
  "unsoundfield-core",
  "unspatial-core",
  "unthermal-core",
+ "untruck-core",
 ]
 
 [[package]]

--- a/crates/unaudiospatial-core/src/lib.rs
+++ b/crates/unaudiospatial-core/src/lib.rs
@@ -3,6 +3,3 @@ pub mod components;
 pub mod emitter;
 pub mod events;
 pub mod listener;
-
-pub const SOUND_SWITCH_ON: &str = "sounds/switch-on-1.ogg";
-pub const SOUND_DINGDINGDING: &str = "sounds/effects-dingdingding.ogg";

--- a/crates/unaudiospatial-core/src/lib.rs
+++ b/crates/unaudiospatial-core/src/lib.rs
@@ -3,3 +3,6 @@ pub mod components;
 pub mod emitter;
 pub mod events;
 pub mod listener;
+
+pub const SOUND_SWITCH_ON: &str = "sounds/switch-on-1.ogg";
+pub const SOUND_DINGDINGDING: &str = "sounds/effects-dingdingding.ogg";

--- a/crates/unaudiospatial-plugin/Cargo.toml
+++ b/crates/unaudiospatial-plugin/Cargo.toml
@@ -14,6 +14,8 @@ workspace = true
 uncommon-states-core = { workspace = true }
 
 unaudiospatial-core = { workspace = true }
+unreplicon-core = { workspace = true }
+untruck-core = { workspace = true }
 unspatial-core = { workspace = true }
 unsettings-core = { workspace = true }
 unmetrics-core = { workspace = true }

--- a/crates/unaudiospatial-plugin/src/plugin.rs
+++ b/crates/unaudiospatial-plugin/src/plugin.rs
@@ -48,6 +48,7 @@ impl Plugin for UnhaunterSpatialAudioPlugin {
                 (
                     local_spatial_audio_playback,
                     spatial_audio_playback,
+                    replicated_spatial_audio_playback,
                     update_spatial_audio,
                     monitor_audio_pileup,
                     process_audio_delayed_despawns,

--- a/crates/unaudiospatial-plugin/src/systems.rs
+++ b/crates/unaudiospatial-plugin/src/systems.rs
@@ -11,6 +11,9 @@ use unaudiospatial_core::components::{
 use unaudiospatial_core::events::{LocalSoundEvent, SoundEvent};
 use unaudiospatial_core::listener::SpatialListener;
 use unmetrics_core::metrics::SendMetric;
+use unreplicon_core::messages::ReplicatedSoundEvent;
+use unreplicon_core::ownership::{LocallyOwned, Owner};
+use untruck_core::components::in_truck::InTruck;
 use unsettings_core::audio::{AudioSettings, SoundOutput};
 use unspatial_core::direction::Direction;
 use unspatial_core::position::Position;
@@ -400,6 +403,211 @@ pub(crate) fn attach_flat_audio(
             DefaultPool,
         ));
     }
+}
+
+pub fn replicated_spatial_audio_playback(
+    mut sound_events: MessageReader<ReplicatedSoundEvent>,
+    asset_server: Res<AssetServer>,
+    qp: Query<(&Position, &Direction, Has<InTruck>), With<SpatialListener>>,
+    mut commands: Commands,
+    audio_settings: Res<Persistent<AudioSettings>>,
+    time: Res<Time>,
+    mut last_error_log: Local<f32>,
+    q_instances: Query<(Entity, &SpatialAudioInstance), Without<SpatialAudioDelayedDespawn>>,
+    q_local_player: Query<&Owner, With<LocallyOwned>>,
+) {
+    let measure = metrics::SOUND_PLAYBACK.time_measure();
+    let now = time.elapsed_secs();
+    let cur_frame = (now * 60.0) as u32;
+    let mut can_log = now - *last_error_log > 1.0;
+
+    let Ok((player_position, player_dir, listener_in_truck)) = qp.single() else {
+        if can_log {
+            warn!("player not found!");
+            *last_error_log = now;
+        }
+        measure.end_ms();
+        return;
+    };
+
+    let local_owner_id = q_local_player.single().ok().map(|o| o.0);
+
+    for replicated_ev in sound_events.read() {
+        if !player_position.is_finite() && can_log {
+            error!("Player position is not finite: {player_position:?}");
+            *last_error_log = now;
+            can_log = false;
+        }
+
+        let mut volume = replicated_ev.volume;
+        let sound_pos = replicated_ev.position.map(|p| Position {
+            x: p[0],
+            y: p[1],
+            z: p[2],
+            ..Default::default()
+        });
+
+        // Triggerer Identification: Penalize those who are not the one who triggered it.
+        let is_triggerer = local_owner_id == Some(replicated_ev.triggerer);
+
+        if !is_triggerer {
+            // Penalization for those that are not the ones to trigger it.
+            // Penalization in the form of severe muffling and lower volume.
+            volume *= 0.4;
+        }
+
+        let mut sound_event = SoundEvent {
+            sound_file: replicated_ev.sound_file.clone(),
+            volume,
+            position: sound_pos,
+        };
+
+        // If the sound happens IN the van, for people OUT of the van should get even more penalty
+        if replicated_ev.is_inside_truck && !listener_in_truck {
+            sound_event.volume *= 0.2;
+        }
+
+        let is_mono = audio_settings.sound_output == SoundOutput::Mono;
+        let mut params =
+            compute_spatial_params(player_position, player_dir, sound_event.position, is_mono);
+
+        // Apply aggressive muffling if not triggerer or if sound is inside truck and listener is outside.
+        if !is_triggerer {
+            params.muffle_cutoff_hz = params.muffle_cutoff_hz.min(1200.0);
+        }
+        if replicated_ev.is_inside_truck && !listener_in_truck {
+            params.muffle_cutoff_hz = params.muffle_cutoff_hz.min(400.0);
+        }
+
+        // Deduplication & Spam Detection
+        let mut is_spam = false;
+        let reverb_file = sound_event.sound_file.replace("sounds/", "reverbs/");
+
+        for (entity, instance) in q_instances.iter() {
+            if instance.sound_file == sound_event.sound_file || instance.sound_file == reverb_file {
+                let frame_diff = cur_frame.saturating_sub(instance.spawn_frame);
+                if !instance.is_reverb && frame_diff < AUDIO_SPAM_FRAME_THRESHOLD {
+                    warn!(
+                        "AUDIO SPAM: Sound '{}' triggered too rapidly ({} frames). Skipping.",
+                        sound_event.sound_file, frame_diff
+                    );
+                    is_spam = true;
+                    break;
+                } else {
+                    commands
+                        .entity(entity)
+                        .insert(SpatialAudioDelayedDespawn::new(0.3));
+                }
+            }
+        }
+
+        if is_spam {
+            continue;
+        }
+
+        let dist = sound_event
+            .position
+            .map(|pos| player_position.distance_zf(&pos, 12.5))
+            .unwrap_or(0.0);
+
+        let base_vol = sound_event.volume
+            * audio_settings.volume_effects.as_f32()
+            * audio_settings.volume_master.as_f32();
+
+        let mut dry_vol = base_vol.clamp(0.0, 1.0);
+
+        let rev_max_ratio = 2.0;
+        let rev_ramp = (dist / 20.0).clamp(0.0, 1.0);
+        let mut rev_vol = (base_vol * rev_max_ratio * rev_ramp).clamp(0.0, 1.0);
+
+        if is_mono {
+            let mono_div = 1.0 + dist * 0.4;
+            dry_vol /= mono_div;
+            rev_vol /= mono_div;
+        }
+
+        let direction = params.direction;
+        let offset = params.offset;
+        let muffle_hz = params.muffle_cutoff_hz;
+        let panning_threshold = params.panning_threshold;
+
+        commands.spawn((
+            SpatialAudioInstance {
+                sound_file: sound_event.sound_file.clone(),
+                is_reverb: false,
+                initial_volume: dry_vol,
+                spawn_time: now,
+                spawn_frame: cur_frame,
+                position: sound_event.position,
+            },
+            SamplePlayer::new(asset_server.load(sound_event.sound_file.clone())),
+            sample_effects![
+                VolumeNode {
+                    volume: Volume::Linear(dry_vol),
+                    smooth_seconds: 0.0005,
+                    ..default()
+                },
+                SpatialBasicNode {
+                    offset,
+                    muffle_cutoff_hz: muffle_hz,
+                    smooth_seconds: 0.0005,
+                    downmix: false,
+                    panning_threshold,
+                    ..default()
+                },
+                (
+                    ItdNode { direction },
+                    ItdConfig {
+                        inter_ear_distance: 0.11,
+                        ..default()
+                    }
+                )
+            ],
+            UnSpatialPool,
+        ));
+
+        if rev_vol > 0.001 {
+            commands.spawn((
+                SpatialAudioInstance {
+                    sound_file: reverb_file.clone(),
+                    is_reverb: true,
+                    initial_volume: rev_vol,
+                    spawn_time: now,
+                    spawn_frame: cur_frame,
+                    position: sound_event.position,
+                },
+                SamplePlayer::new(asset_server.load(reverb_file)),
+                sample_effects![
+                    VolumeNode {
+                        volume: Volume::Linear(rev_vol),
+                        smooth_seconds: 0.0005,
+                        ..default()
+                    },
+                    SpatialBasicNode {
+                        offset,
+                        muffle_cutoff_hz: muffle_hz,
+                        distance_attenuation: DistanceAttenuation {
+                            distance_gain_factor: 0.25,
+                            ..default()
+                        },
+                        smooth_seconds: 0.0005,
+                        downmix: false,
+                        panning_threshold,
+                        ..default()
+                    },
+                    (
+                        ItdNode { direction },
+                        ItdConfig {
+                            inter_ear_distance: 0.11,
+                            ..default()
+                        }
+                    )
+                ],
+                UnSpatialPool,
+            ));
+        }
+    }
+    measure.end_ms();
 }
 
 pub fn update_spatial_audio(

--- a/crates/unaudiospatial-plugin/src/systems.rs
+++ b/crates/unaudiospatial-plugin/src/systems.rs
@@ -248,7 +248,7 @@ fn play_sound_event(
     }
 }
 
-pub fn local_spatial_audio_playback(
+pub(crate) fn local_spatial_audio_playback(
     mut sound_events: MessageReader<LocalSoundEvent>,
     asset_server: Res<AssetServer>,
     qp: Query<(&Position, &Direction), With<SpatialListener>>,
@@ -294,7 +294,7 @@ pub fn local_spatial_audio_playback(
     measure.end_ms();
 }
 
-pub fn spatial_audio_playback(
+pub(crate) fn spatial_audio_playback(
     mut sound_events: MessageReader<SoundEvent>,
     asset_server: Res<AssetServer>,
     qp: Query<(&Position, &Direction), With<SpatialListener>>,
@@ -339,7 +339,7 @@ pub fn spatial_audio_playback(
     measure.end_ms();
 }
 
-pub fn process_audio_delayed_despawns(
+pub(crate) fn process_audio_delayed_despawns(
     mut commands: Commands,
     time: Res<Time>,
     mut q_fadeouts: Query<(Entity, &mut SpatialAudioDelayedDespawn)>,
@@ -352,7 +352,7 @@ pub fn process_audio_delayed_despawns(
     }
 }
 
-pub fn monitor_audio_pileup(
+pub(crate) fn monitor_audio_pileup(
     q_audio_players: Query<&SamplePlayer>,
     time: Res<Time>,
     asset_server: Res<AssetServer>,
@@ -405,7 +405,7 @@ pub(crate) fn attach_flat_audio(
     }
 }
 
-pub fn replicated_spatial_audio_playback(
+pub(crate) fn replicated_spatial_audio_playback(
     mut sound_events: MessageReader<ReplicatedSoundEvent>,
     asset_server: Res<AssetServer>,
     qp: Query<(&Position, &Direction, Has<InTruck>), With<SpatialListener>>,
@@ -610,7 +610,7 @@ pub fn replicated_spatial_audio_playback(
     measure.end_ms();
 }
 
-pub fn update_spatial_audio(
+pub(crate) fn update_spatial_audio(
     qp: Query<(&Position, &Direction), With<SpatialListener>>,
     audio_settings: Res<Persistent<AudioSettings>>,
     q_audio: Query<(&SpatialAudioInstance, &SampleEffects)>,

--- a/crates/ungearitems-plugin/Cargo.toml
+++ b/crates/ungearitems-plugin/Cargo.toml
@@ -22,6 +22,7 @@ unrender-std = { workspace = true }
 uninteraction-core = { workspace = true }
 unmetrics-core = { workspace = true }
 ungear-core = { workspace = true }
+untruck-core = { workspace = true }
 unghost-core = { workspace = true }
 uninvestigation-core = { workspace = true }
 unfog-core = { workspace = true }

--- a/crates/ungearitems-plugin/src/net_state.rs
+++ b/crates/ungearitems-plugin/src/net_state.rs
@@ -14,7 +14,7 @@
 //! pattern stabilises. See `ExportClientComponent` docs for details.
 
 use bevy::prelude::*;
-use bevy_replicon::prelude::{Channel, ClientId, ClientMessageAppExt, FromClient, Replicated};
+use bevy_replicon::prelude::*;
 use uncommon_states_core::UIContextState;
 use undifficulty_core::current_difficulty::CurrentDifficulty;
 use undifficulty_core::difficulty_settings::DifficultySettings;
@@ -29,8 +29,11 @@ use ungearitems_core::events::RepellentHitNetMessage;
 use unghost_core::components::logic::ghost_sprite::GhostSprite;
 use uninteraction_core::interaction::Toggleable;
 use unreplicon_core::client_export::ExportClientComponent;
+use unreplicon_core::messages::ReplicatedSoundEvent;
 use unreplicon_core::ownership::{LocallyOwned, Owner, OwnerId};
 use unreplicon_core::resources::{AuthorityRole, LocalPlayerRole, is_pure_client};
+use unspatial_core::position::Position;
+use untruck_core::components::in_truck::InTruck;
 
 pub(crate) fn app_setup(app: &mut App) {
     app.add_client_message::<RepellentHitNetMessage>(Channel::Unreliable);
@@ -104,6 +107,13 @@ fn from_owner_id(owner_id: OwnerId) -> ClientId {
     match owner_id {
         OwnerId::Server => ClientId::Server,
         OwnerId::Client(e) => ClientId::Client(e),
+    }
+}
+
+fn to_owner_id(client_id: ClientId) -> OwnerId {
+    match client_id {
+        ClientId::Server => OwnerId::Server,
+        ClientId::Client(e) => OwnerId::Client(e),
     }
 }
 
@@ -234,13 +244,21 @@ fn send_export_toggleable(
 fn handle_import_flashlight(
     mut reader: MessageReader<FromClient<ExportClientComponent<Flashlight>>>,
     mut q_gear: Query<
-        (&Owner, &mut Flashlight, Option<&mut Toggleable>),
+        (
+            &Owner,
+            &mut Flashlight,
+            Option<&mut Toggleable>,
+            Option<&Position>,
+            Has<InTruck>,
+        ),
         (Without<LocallyOwned>, With<Replicated>),
     >,
+    mut ev_replicated_sound: MessageWriter<ToClients<ReplicatedSoundEvent>>,
 ) {
     for msg in reader.read() {
         let entity = msg.message.entity;
-        let Ok((owner, mut flashlight, toggleable)) = q_gear.get_mut(entity) else {
+        let Ok((owner, mut flashlight, toggleable, pos, in_truck)) = q_gear.get_mut(entity)
+        else {
             warn!("handle_import_flashlight: entity {:?} not found", entity);
             continue;
         };
@@ -257,6 +275,17 @@ fn handle_import_flashlight(
                 "RECV: UPDATING FLASHLIGHT: Entity: {:?}, New Status: {:?}",
                 entity, msg.message.data.status
             );
+
+            ev_replicated_sound.write(ToClients {
+                mode: SendMode::Broadcast,
+                message: ReplicatedSoundEvent {
+                    sound_file: "sounds/switch-on-1.ogg".to_string(),
+                    volume: 1.0,
+                    position: pos.map(|p: &Position| [p.x, p.y, p.z]),
+                    triggerer: to_owner_id(msg.client_id),
+                    is_inside_truck: in_truck,
+                },
+            });
         }
         *flashlight = msg.message.data.clone();
         if let Some(mut t) = toggleable {
@@ -268,19 +297,39 @@ fn handle_import_flashlight(
 fn handle_import_uvtorch(
     mut reader: MessageReader<FromClient<ExportClientComponent<UVTorch>>>,
     mut q_gear: Query<
-        (&Owner, &mut UVTorch, Option<&mut Toggleable>),
+        (
+            &Owner,
+            &mut UVTorch,
+            Option<&mut Toggleable>,
+            Option<&Position>,
+            Has<InTruck>,
+        ),
         (Without<LocallyOwned>, With<Replicated>),
     >,
+    mut ev_replicated_sound: MessageWriter<ToClients<ReplicatedSoundEvent>>,
 ) {
     for msg in reader.read() {
         let entity = msg.message.entity;
-        let Ok((owner, mut uvtorch, toggleable)) = q_gear.get_mut(entity) else {
+        let Ok((owner, mut uvtorch, toggleable, pos, in_truck)) = q_gear.get_mut(entity)
+        else {
             warn!("handle_import_uvtorch: entity {:?} not found", entity);
             continue;
         };
         if from_owner_id(owner.0) != msg.client_id {
             warn!("handle_import_uvtorch: ownership mismatch for {:?}", entity);
             continue;
+        }
+        if uvtorch.enabled != msg.message.data.enabled {
+            ev_replicated_sound.write(ToClients {
+                mode: SendMode::Broadcast,
+                message: ReplicatedSoundEvent {
+                    sound_file: "sounds/switch-on-1.ogg".to_string(),
+                    volume: 1.0,
+                    position: pos.map(|p: &Position| [p.x, p.y, p.z]),
+                    triggerer: to_owner_id(msg.client_id),
+                    is_inside_truck: in_truck,
+                },
+            });
         }
         let enabled = msg.message.data.enabled;
         *uvtorch = msg.message.data.clone();
@@ -293,13 +342,21 @@ fn handle_import_uvtorch(
 fn handle_import_redtorch(
     mut reader: MessageReader<FromClient<ExportClientComponent<RedTorch>>>,
     mut q_gear: Query<
-        (&Owner, &mut RedTorch, Option<&mut Toggleable>),
+        (
+            &Owner,
+            &mut RedTorch,
+            Option<&mut Toggleable>,
+            Option<&Position>,
+            Has<InTruck>,
+        ),
         (Without<LocallyOwned>, With<Replicated>),
     >,
+    mut ev_replicated_sound: MessageWriter<ToClients<ReplicatedSoundEvent>>,
 ) {
     for msg in reader.read() {
         let entity = msg.message.entity;
-        let Ok((owner, mut redtorch, toggleable)) = q_gear.get_mut(entity) else {
+        let Ok((owner, mut redtorch, toggleable, pos, in_truck)) = q_gear.get_mut(entity)
+        else {
             warn!("handle_import_redtorch: entity {:?} not found", entity);
             continue;
         };
@@ -309,6 +366,18 @@ fn handle_import_redtorch(
                 entity
             );
             continue;
+        }
+        if redtorch.enabled != msg.message.data.enabled {
+            ev_replicated_sound.write(ToClients {
+                mode: SendMode::Broadcast,
+                message: ReplicatedSoundEvent {
+                    sound_file: "sounds/switch-on-1.ogg".to_string(),
+                    volume: 1.0,
+                    position: pos.map(|p: &Position| [p.x, p.y, p.z]),
+                    triggerer: to_owner_id(msg.client_id),
+                    is_inside_truck: in_truck,
+                },
+            });
         }
         let enabled = msg.message.data.enabled;
         *redtorch = msg.message.data.clone();
@@ -404,11 +473,15 @@ fn handle_import_quartz(
 /// on the send side and will not produce these messages.
 fn handle_import_toggleable(
     mut reader: MessageReader<FromClient<ExportClientComponent<Toggleable>>>,
-    mut q_gear: Query<(&Owner, &mut Toggleable), (Without<LocallyOwned>, With<Replicated>)>,
+    mut q_gear: Query<
+        (&Owner, &mut Toggleable, Option<&Position>, Has<InTruck>),
+        (Without<LocallyOwned>, With<Replicated>),
+    >,
+    mut ev_replicated_sound: MessageWriter<ToClients<ReplicatedSoundEvent>>,
 ) {
     for msg in reader.read() {
         let entity = msg.message.entity;
-        let Ok((owner, mut toggleable)) = q_gear.get_mut(entity) else {
+        let Ok((owner, mut toggleable, pos, in_truck)) = q_gear.get_mut(entity) else {
             warn!("handle_import_toggleable: entity {:?} not found", entity);
             continue;
         };
@@ -418,6 +491,18 @@ fn handle_import_toggleable(
                 entity
             );
             continue;
+        }
+        if toggleable.is_on != msg.message.data.is_on {
+            ev_replicated_sound.write(ToClients {
+                mode: SendMode::Broadcast,
+                message: ReplicatedSoundEvent {
+                    sound_file: "sounds/switch-on-1.ogg".to_string(),
+                    volume: 1.0,
+                    position: pos.map(|p: &Position| [p.x, p.y, p.z]),
+                    triggerer: to_owner_id(msg.client_id),
+                    is_inside_truck: in_truck,
+                },
+            });
         }
         *toggleable = msg.message.data;
     }

--- a/crates/unplayer-plugin/src/systems/input/mouse_interaction.rs
+++ b/crates/unplayer-plugin/src/systems/input/mouse_interaction.rs
@@ -1,21 +1,28 @@
 use bevy::prelude::*;
+use bevy_replicon::prelude::{SendMode, ToClients};
 use unaudiospatial_core::emitter::LocalAudioEmitter;
 use ungear_core::components::playergear::PlayerGear;
 use uninput_core::components::PlayerInput;
 use uninteraction_core::interaction::{Toggleable, Triggered};
 use unplayer_core::components::{MainPlayer, PlayerSpectating, PlayerSprite};
+use unreplicon_core::messages::ReplicatedSoundEvent;
+use unreplicon_core::ownership::OwnerId;
+use unreplicon_core::resources::AuthorityRole;
 use unspatial_core::position::Position;
+use untruck_core::components::in_truck::InTruck;
 
 pub(crate) fn toggle_gear_from_use_intent(
     mut commands: Commands,
     mut q_players: Query<
-        (&PlayerGear, &mut PlayerInput, Option<&MainPlayer>),
+        (&PlayerGear, &mut PlayerInput, Option<&MainPlayer>, Has<InTruck>),
         (With<PlayerSprite>, Without<PlayerSpectating>),
     >,
     mut q_toggleable: Query<(&mut Toggleable, Option<&Position>)>,
-    mut ga: LocalAudioEmitter,
+    _ga: LocalAudioEmitter,
+    mut ev_replicated_sound: MessageWriter<ToClients<ReplicatedSoundEvent>>,
+    authority: Option<Res<AuthorityRole>>,
 ) {
-    for (player_gear, mut player_input, main_player) in q_players.iter_mut() {
+    for (player_gear, mut player_input, main_player, in_truck) in q_players.iter_mut() {
         let is_main = main_player.is_some();
         if player_input.use_right_hand {
             player_input.use_right_hand = false;
@@ -34,12 +41,21 @@ pub(crate) fn toggle_gear_from_use_intent(
 
                     if toggle.is_on != target_on {
                         toggle.is_on = target_on;
-                        if let Some(pos) = pos {
-                            if is_main {
-                                ga.play_audio("sounds/switch-on-1.ogg".into(), 1.0, pos);
-                            }
-                        } else if is_main {
-                            ga.play_audio_nopos("sounds/switch-on-1.ogg".into(), 1.0);
+
+                        if is_main && authority.is_some() {
+                            let sound_file = "sounds/switch-on-1.ogg".to_string();
+                            let triggerer = OwnerId::Server; // Host player is server in this context
+
+                            ev_replicated_sound.write(ToClients {
+                                mode: SendMode::Broadcast,
+                                message: ReplicatedSoundEvent {
+                                    sound_file,
+                                    volume: 1.0,
+                                    position: pos.map(|p| [p.x, p.y, p.z]),
+                                    triggerer,
+                                    is_inside_truck: in_truck,
+                                },
+                            });
                         }
                     }
                 }
@@ -63,12 +79,21 @@ pub(crate) fn toggle_gear_from_use_intent(
 
                     if toggle.is_on != target_on {
                         toggle.is_on = target_on;
-                        if let Some(pos) = pos {
-                            if is_main {
-                                ga.play_audio("sounds/switch-on-1.ogg".into(), 1.0, pos);
-                            }
-                        } else if is_main {
-                            ga.play_audio_nopos("sounds/switch-on-1.ogg".into(), 1.0);
+
+                        if is_main && authority.is_some() {
+                            let sound_file = "sounds/switch-on-1.ogg".to_string();
+                            let triggerer = OwnerId::Server;
+
+                            ev_replicated_sound.write(ToClients {
+                                mode: SendMode::Broadcast,
+                                message: ReplicatedSoundEvent {
+                                    sound_file,
+                                    volume: 1.0,
+                                    position: pos.map(|p| [p.x, p.y, p.z]),
+                                    triggerer,
+                                    is_inside_truck: in_truck,
+                                },
+                            });
                         }
                     }
                 }

--- a/crates/unreplicon-core/src/messages.rs
+++ b/crates/unreplicon-core/src/messages.rs
@@ -224,6 +224,33 @@ pub struct FloorGearDespawnBroadcast {
 
 // ---------------------------------------------------------------------------
 // Phase 4: Ghost, Evidence, and Mission messages
+
+/// Broadcast by the server to all clients to play a sound effect.
+///
+/// This message is used for one-shot sound effects that should be heard by all
+/// players, such as gear interactions or truck UI sounds.
+#[derive(Debug, Clone, Serialize, Deserialize, Message)]
+pub struct ReplicatedSoundEvent {
+    pub sound_file: String,
+    pub volume: f32,
+    pub position: Option<[f32; 3]>,
+    /// The client or server that triggered this sound. Used to apply penalties
+    /// for other players (muffling/volume reduction).
+    pub triggerer: crate::ownership::OwnerId,
+    /// Indicates if the sound originated inside the truck.
+    /// This is used to apply extra muffling for players (e.g. if the sound happens
+    /// in the van and the listener is outside, we apply more penalty).
+    pub is_inside_truck: bool,
+}
+
+impl bevy::ecs::entity::MapEntities for ReplicatedSoundEvent {
+    fn map_entities<M: bevy::ecs::entity::EntityMapper>(&mut self, mapper: &mut M) {
+        if let crate::ownership::OwnerId::Client(entity) = &mut self.triggerer {
+            *entity = mapper.get_mapped(*entity);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 
 /// Broadcast by the server to all clients to spawn a visual particle effect.

--- a/crates/unreplicon-plugin/src/systems/ghost.rs
+++ b/crates/unreplicon-plugin/src/systems/ghost.rs
@@ -6,7 +6,9 @@ use unmission_core::types::SimulationState;
 use unreplicon_core::components::{
     MissionGoalEntity, RepliconGhostSpawningActive, ServerGamePhase,
 };
-use unreplicon_core::messages::{GhostSoundFieldBroadcast, SpawnParticleNetEvent};
+use unreplicon_core::messages::{
+    GhostSoundFieldBroadcast, ReplicatedSoundEvent, SpawnParticleNetEvent,
+};
 use unreplicon_core::repellent_tracker::RepellentCraftTracker;
 use unreplicon_core::resources::{AuthorityRole, is_pure_client};
 
@@ -19,6 +21,7 @@ pub(super) fn app_setup(app: &mut App) {
     // Register server → client messages.
     app.add_server_message::<SpawnParticleNetEvent>(Channel::Ordered);
     app.add_server_message::<GhostSoundFieldBroadcast>(Channel::Ordered);
+    app.add_mapped_server_message::<ReplicatedSoundEvent>(Channel::Ordered);
 
     app.add_systems(
         OnEnter(SimulationState::Spawning),

--- a/crates/untruck-plugin/src/systems/truck_ui_systems.rs
+++ b/crates/untruck-plugin/src/systems/truck_ui_systems.rs
@@ -1,8 +1,6 @@
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy_replicon::prelude::*;
-use unaudiospatial_core::SOUND_DINGDINGDING;
-use unaudiospatial_core::components::{AudioCategory, FlatAudio};
 use undifficulty_core::current_difficulty::CurrentDifficulty;
 use undifficulty_core::difficulty_settings::DifficultySettings;
 use ungear_core::messages::{TruckLoadoutAction, TruckLoadoutMessage};
@@ -56,7 +54,7 @@ fn truckui_event_handle(
     mut ev_replicated_sound: MessageWriter<ToClients<ReplicatedSoundEvent>>,
     net_params: TruckNetParams,
     authority: Option<Res<AuthorityRole>>,
-    local_player_role: Option<Res<LocalPlayerRole>>,
+    _local_player_role: Option<Res<LocalPlayerRole>>,
     lobby_presence: Option<Res<LobbyPresenceRole>>,
     q_player: Query<(Entity, &Position), (With<MainPlayer>, With<InTruck>)>,
 ) {
@@ -76,18 +74,14 @@ fn truckui_event_handle(
                 }
 
                 if authority.is_some() {
-                    let triggerer = if let Some(role) = &local_player_role {
-                        OwnerId::Client(role.entity)
-                    } else {
-                        OwnerId::Server
-                    };
-
+                    // Authority/Host player clicked it.
+                    let triggerer = OwnerId::Server;
                     let player_pos = q_player.iter().next().map(|(_, p)| [p.x, p.y, p.z]);
 
                     ev_replicated_sound.write(ToClients {
                         mode: SendMode::Broadcast,
                         message: ReplicatedSoundEvent {
-                            sound_file: SOUND_DINGDINGDING.to_string(),
+                            sound_file: "sounds/effects-dingdingding.ogg".to_string(),
                             volume: 1.0,
                             position: player_pos,
                             triggerer,
@@ -122,7 +116,7 @@ fn truckui_event_handle(
                     debug!(
                         "REPELLENT: TruckUIEvent::CraftRepellent received authority={} local_player_role={} main_players_in_truck={:?} ghost_type={:?}",
                         authority.is_some(),
-                        local_player_role.is_some(),
+                        _local_player_role.is_some(),
                         in_truck_main_players,
                         ghost_type,
                     );
@@ -141,11 +135,7 @@ fn truckui_event_handle(
                             ghost_type
                         );
 
-                        let triggerer = if let Some(role) = &local_player_role {
-                            OwnerId::Client(role.entity)
-                        } else {
-                            OwnerId::Server
-                        };
+                        let triggerer = OwnerId::Server;
 
                         let player_pos = q_player
                             .iter()
@@ -155,7 +145,7 @@ fn truckui_event_handle(
                         ev_replicated_sound.write(ToClients {
                             mode: SendMode::Broadcast,
                             message: ReplicatedSoundEvent {
-                                sound_file: SOUND_DINGDINGDING.to_string(),
+                                sound_file: "sounds/effects-dingdingding.ogg".to_string(),
                                 volume: 1.0,
                                 position: player_pos,
                                 triggerer,

--- a/crates/untruck-plugin/src/systems/truck_ui_systems.rs
+++ b/crates/untruck-plugin/src/systems/truck_ui_systems.rs
@@ -1,11 +1,15 @@
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
-use bevy_replicon::prelude::Remote;
+use bevy_replicon::prelude::*;
+use unaudiospatial_core::SOUND_DINGDINGDING;
 use unaudiospatial_core::components::{AudioCategory, FlatAudio};
 use undifficulty_core::current_difficulty::CurrentDifficulty;
 use undifficulty_core::difficulty_settings::DifficultySettings;
 use ungear_core::messages::{TruckLoadoutAction, TruckLoadoutMessage};
 use ungearitems_core::events::RequestCraftRepellent;
+use unreplicon_core::messages::ReplicatedSoundEvent;
+use unreplicon_core::ownership::OwnerId;
+use unspatial_core::position::Position;
 use uninput_core::states::InGameUiState;
 use uninvestigation_core::components::ghost_guess::GhostGuess;
 use unmission_core::resources::MissionEndRequested;
@@ -49,11 +53,12 @@ fn truckui_event_handle(
     mut ev_loadout: MessageWriter<TruckLoadoutMessage>,
     mut ev_end_mission: MessageWriter<RequestEndMission>,
     mut ev_mission: MessageWriter<MissionEvent>,
+    mut ev_replicated_sound: MessageWriter<ToClients<ReplicatedSoundEvent>>,
     net_params: TruckNetParams,
     authority: Option<Res<AuthorityRole>>,
     local_player_role: Option<Res<LocalPlayerRole>>,
     lobby_presence: Option<Res<LobbyPresenceRole>>,
-    q_player: Query<Entity, (With<MainPlayer>, With<InTruck>)>,
+    q_player: Query<(Entity, &Position), (With<MainPlayer>, With<InTruck>)>,
 ) {
     if ev_truckui.is_empty() {
         return;
@@ -69,6 +74,28 @@ fn truckui_event_handle(
                 if !net_params.mission_end_requested.0 {
                     continue;
                 }
+
+                if authority.is_some() {
+                    let triggerer = if let Some(role) = &local_player_role {
+                        OwnerId::Client(role.entity)
+                    } else {
+                        OwnerId::Server
+                    };
+
+                    let player_pos = q_player.iter().next().map(|(_, p)| [p.x, p.y, p.z]);
+
+                    ev_replicated_sound.write(ToClients {
+                        mode: SendMode::Broadcast,
+                        message: ReplicatedSoundEvent {
+                            sound_file: SOUND_DINGDINGDING.to_string(),
+                            volume: 1.0,
+                            position: player_pos,
+                            triggerer,
+                            is_inside_truck: true,
+                        },
+                    });
+                }
+
                 if lobby_presence.is_none() {
                     // TODO(multiplayer-first): remove once single-player uses a local in-memory transport.
                     // Offline single-player: no network transport exists, so RequestEndMission
@@ -84,13 +111,13 @@ fn truckui_event_handle(
                 }
             }
             TruckUIEvent::ExitTruck => {
-                for entity in q_player.iter() {
+                for (entity, _) in q_player.iter() {
                     commands.entity(entity).remove::<InTruck>();
                 }
             }
             TruckUIEvent::CraftRepellent => {
                 if let Some(ghost_type) = gg.ghost_type {
-                    let in_truck_main_players: Vec<Entity> = q_player.iter().collect();
+                    let in_truck_main_players: Vec<Entity> = q_player.iter().map(|(e, _)| e).collect();
 
                     debug!(
                         "REPELLENT: TruckUIEvent::CraftRepellent received authority={} local_player_role={} main_players_in_truck={:?} ghost_type={:?}",
@@ -113,6 +140,29 @@ fn truckui_event_handle(
                             "REPELLENT: Craft repellent requested on authority node; writing local RequestCraftRepellent for ghost_type={:?}",
                             ghost_type
                         );
+
+                        let triggerer = if let Some(role) = &local_player_role {
+                            OwnerId::Client(role.entity)
+                        } else {
+                            OwnerId::Server
+                        };
+
+                        let player_pos = q_player
+                            .iter()
+                            .find(|(e, _)| *e == player_entity)
+                            .map(|(_, p)| [p.x, p.y, p.z]);
+
+                        ev_replicated_sound.write(ToClients {
+                            mode: SendMode::Broadcast,
+                            message: ReplicatedSoundEvent {
+                                sound_file: SOUND_DINGDINGDING.to_string(),
+                                volume: 1.0,
+                                position: player_pos,
+                                triggerer,
+                                is_inside_truck: true,
+                            },
+                        });
+
                         ev_craft_req.write(RequestCraftRepellent {
                             ghost_type,
                             player_entity,
@@ -122,12 +172,6 @@ fn truckui_event_handle(
                             "REPELLENT: Craft repellent requested on authority node, but no MainPlayer found in truck!"
                         );
                     }
-
-                    commands.spawn((FlatAudio {
-                        sound_file: "sounds/effects-dingdingding.ogg".to_string(),
-                        volume_multiplier: 1.0,
-                        category: AudioCategory::Effects,
-                    },));
                 } else {
                     warn!(
                         "REPELLENT: CraftRepellent requested but no ghost type selected in journal"


### PR DESCRIPTION
This PR implements shared positional audio for truck UI interactions and gear activation clicks. 

Key changes:
1.  **Replicated Sound Messaging**: Added `ReplicatedSoundEvent` in `unreplicon-core`, registered in `unreplicon-plugin`. This message carries the sound file, volume, position, triggerer's `OwnerId`, and an `is_inside_truck` flag.
2.  **Positional Audio Penalties**: Implemented `replicated_spatial_audio_playback` in `unaudiospatial-plugin`. It applies:
    -   A **0.4x volume multiplier** and **1200Hz low-pass muffle** for anyone who did not trigger the sound.
    -   An additional **0.2x volume multiplier** and **400Hz low-pass muffle** for players who are outside the truck hearing a sound that originated inside.
3.  **Truck UI Updates**: Modified `untruck-plugin` so "End Mission" and "Craft Repellent" broadcast the "dingdingding" sound to all players.
4.  **Gear Interaction Updates**: 
    -   Updated `unplayer-plugin` to broadcast switch sounds for the local host.
    -   Updated `ungearitems-plugin` network import handlers to broadcast switch sounds when remote clients toggle their gear.
5.  **Clean Asset Referencing**: Uses asset paths directly in code as requested, avoiding unnecessary constant redirection.

The build has been verified with `cargo check` for the entire workspace.

---
*PR created automatically by Jules for task [4649928476135556390](https://jules.google.com/task/4649928476135556390) started by @deavid*